### PR TITLE
Improve time complexity of '_byte_pair_merge' and add test

### DIFF
--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -6,16 +6,17 @@ import os
 import random
 import time
 from typing import Any, cast
+import numpy as np
 
 import blobfile
 
 import tiktoken
 
 
-def benchmark_batch(documents: list[str]) -> None:
-    num_threads = int(os.environ["RAYON_NUM_THREADS"])
+def benchmark_batch(documents: list[str], num_threads: int) -> None:
+    # num_threads = 1#int(os.environ["RAYON_NUM_THREADS"])
     num_bytes = sum(map(len, map(str.encode, documents)))
-    print(f"num_threads: {num_threads}, num_bytes: {num_bytes}")
+    # print(f"num_threads: {num_threads}, num_bytes: {num_bytes}")
 
     enc = tiktoken.get_encoding("gpt2")
     enc.encode("warmup")
@@ -23,7 +24,9 @@ def benchmark_batch(documents: list[str]) -> None:
     start = time.perf_counter_ns()
     enc.encode_ordinary_batch(documents, num_threads=num_threads)
     end = time.perf_counter_ns()
-    print(f"tiktoken \t{num_bytes / (end - start) * 1e9} bytes / s")
+    # print(f"tiktoken \t{num_bytes / (end - start) * 1e9} bytes / s")
+
+    return num_bytes / (end - start) * 1e9
 
     import transformers
 
@@ -36,4 +39,32 @@ def benchmark_batch(documents: list[str]) -> None:
     end = time.perf_counter_ns()
     print(f"huggingface \t{num_bytes / (end - start) * 1e9} bytes / s")
 
+    return num_bytes / (end - start) * 1e9
 
+
+import base64, random
+
+
+def base64_noise_documents(n_docs: int):
+    rand = random.Random(217)
+    documents = []
+    for _ in range(n_docs):
+        documents.append(
+            base64.b64encode(rand.randbytes(rand.randint(100, 10_000))).decode()
+        )
+    return documents
+
+
+def run_benchmark(batch_size, num_threads):
+    return np.mean(
+        [
+            benchmark_batch(base64_noise_documents(1000), num_threads=num_threads)
+            for _ in range(batch_size)
+        ]
+    )
+
+
+print("threads,bytes_per_second")
+for thread_count in range(1, 12, 2):
+    bytes_per_second = run_benchmark(10, thread_count)
+    print(f"{thread_count},{bytes_per_second}")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@ fn _byte_pair_merge(piece: &[u8], ranks: &HashMap<Vec<u8>, usize>) -> Vec<std::o
     let mut curr_start = 0;
     let mut curr_end = next[0].unwrap();
     loop {
-        result.push((curr_start..curr_end).clone());
+        result.push(curr_start..curr_end);
         curr_start = curr_end;
         curr_end = match next[curr_end] {
             Some(end) => end,


### PR DESCRIPTION
I saw the comment in the byte_pair_merge code about improving the time complexity and thought it sounded interesting. I'm interested to see how the overall throughput of tiktoken changes with this change. I'll work on benchmarking it when I get a chance