### PR TITLE
Improve performance by 2x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ pyo3 = { version = "0.17.3", features = ["extension-module"] }
 
 # tiktoken dependencies
 fancy-regex = "0.10.0"
-pcre2 = { git = "https://github.com/nistath/rust-pcre2/" }
+regex = "1.7.0"
 rustc-hash = "1.1.0"
 bstr = "1.0.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ pyo3 = { version = "0.17.3", features = ["extension-module"] }
 
 # tiktoken dependencies
 fancy-regex = "0.10.0"
-regex = "1.7.0"
+pcre2 = { git = "https://github.com/nistath/rust-pcre2/" }
 rustc-hash = "1.1.0"
 bstr = "1.0.1"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,9 @@
 #![allow(clippy::borrow_deref_ref)]
 
 use std::collections::HashSet;
+use std::thread;
 
-use pcre2::bytes::{Regex, RegexBuilder};
+use fancy_regex::Regex;
 use pyo3::exceptions;
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyList, PyTuple};
@@ -123,34 +124,20 @@ pub fn byte_pair_split<'a>(piece: &'a [u8], ranks: &HashMap<Vec<u8>, usize>) -> 
 //
 // Regex
 // =====
-// A considerable amount of time is spent in regex.
-// The easiest way to speed this up is by using a faster regex parser.
-// A reason performance varies across parsers might be their feature richness
-// The `fast_regex` crate can parse more kinds of regex than the `regex` crate.
-// Another reason, could be the implementation of the parser and whether it
-// has a JIT compiler capable of generating optimized code during pattern compilation.
-// `pcre2` is a C library that has such JIT capabilities and is wrapped in the `pcre2` crate.
+// Most of the time is spent in regex. The easiest way to speed this up is by using less fancy
+// regex features. For instance, using a regex parse-able by `regex` crate is 3x faster than
+// the usual regex we use.
 //
-// Given that we're using a regex that can be parsed by all of the above packages,
-// we chose to use `pcre2` due to its superior performance.
+// However, given that we're using a regex parse-able by `regex`, there isn't much difference
+// between using the `regex` crate and using the `fancy_regex` crate.
 //
-// There is an important interaction between threading and `prce2`.
-// `pcre2` uses scratch space, `pcre2::ffi::MatchData`, that may only be used by one thread at
-// a time. Internally, `pcre2::Regex` uses a `thread_local::ThreadLocal` to manage a pool
-// of copies of the scratch space. If a new thread is created, it will incur a penalty
-// when allocating a copy of this space. There are also internal mutexes on which there
-// will be contention if there are multiple new threads making scratch space.
-// Thus, it is recommended to keep the threads alive, for example, using a thread pool.
-//
-// There are a couple potentially better designs to consider:
-// 1. Have each thread explicitly own its own scratch space as opposed to looking it up in the
-//    `thread_local::ThreadLocal`. This would require the user (us) to manage these, which involves
-//    adjusting the `Encoding` Python class to keep track.
-// 2. Another option would be to have a lock-free object pool of scratch space and pull from it
-//    whenever necessary, allocating if the pool is empty. This is agnostic to the thread that is
-//    requesting scratch space and thus more flexible. However, there could be contention on the
-//    internal linked-list and CPU-cache innefficiencies considering that the scratch space
-//    could have been residing on another core's cache.
+// There is an important interaction between threading, `regex` and `fancy_regex`.
+// When using `fancy_regex`, we hit `regex.find_at`. It turns out that this causes contention on
+// some mutable scratch space inside of `regex`. This absolutely kills performance. When using plain
+// old `regex`, we don't hit this, because `find_iter` has a different code path.
+// Related: https://github.com/rust-lang/regex/blob/master/PERFORMANCE.md
+// Anyway, the way we get around this is with having a (mostly) thread local clone of the regex for
+// each thread.
 //
 // Threading
 // =========
@@ -176,18 +163,44 @@ pub fn byte_pair_split<'a>(piece: &'a [u8], ranks: &HashMap<Vec<u8>, usize>) -> 
 
 use std::num::NonZeroU64;
 pub struct FakeThreadId(NonZeroU64);
+
+fn hash_current_thread() -> usize {
+    // It's easier to use unsafe than to use nightly. Rust has this nice u64 thread id counter
+    // that works great for our use case of avoiding collisions in our array. Unfortunately,
+    // it's private. However, there are only so many ways you can layout a u64, so just transmute
+    // https://github.com/rust-lang/rust/issues/67939
+    const _: [u8; 8] = [0; std::mem::size_of::<std::thread::ThreadId>()];
+    const _: [u8; 8] = [0; std::mem::size_of::<FakeThreadId>()];
+    let x = unsafe {
+        std::mem::transmute::<std::thread::ThreadId, FakeThreadId>(thread::current().id()).0
+    };
+    u64::from(x) as usize
+}
+
+const MAX_NUM_THREADS: usize = 128;
 #[pyclass]
-pub struct CoreBPE {
+struct CoreBPE {
     encoder: HashMap<Vec<u8>, usize>,
     special_tokens_encoder: HashMap<String, usize>,
     decoder: HashMap<usize, Vec<u8>>,
     special_tokens_decoder: HashMap<usize, Vec<u8>>,
-    regex: Regex,
-    special_regex: Regex,
+    regex_tls: Vec<Regex>,
+    special_regex_tls: Vec<Regex>,
     sorted_token_bytes: Vec<Vec<u8>>,
 }
 
 impl CoreBPE {
+    fn _get_tl_regex(&self) -> &Regex {
+        // See performance notes above for what this is about
+        // It's also a little janky, please make a better version of it!
+        // However, it's nice that this doesn't leak memory to short-lived threads
+        &self.regex_tls[hash_current_thread() % MAX_NUM_THREADS]
+    }
+
+    fn _get_tl_special_regex(&self) -> &Regex {
+        &self.special_regex_tls[hash_current_thread() % MAX_NUM_THREADS]
+    }
+
     fn _decode_native(&self, tokens: &[usize]) -> Vec<u8> {
         let mut ret = Vec::with_capacity(tokens.len() * 2);
         for token in tokens {
@@ -203,9 +216,10 @@ impl CoreBPE {
     fn _encode_ordinary_native(&self, text: &str) -> Vec<usize> {
         // This is the core of the encoding logic; the other functions in here
         // just make things complicated :-)
+        let regex = self._get_tl_regex();
         let mut ret = vec![];
-        for mat in self.regex.find_iter(text.as_bytes()) {
-            let piece = mat.unwrap().as_bytes();
+        for mat in regex.find_iter(text) {
+            let piece = mat.unwrap().as_str().as_bytes();
             if let Some(token) = self.encoder.get(piece) {
                 ret.push(*token);
                 continue;
@@ -216,6 +230,8 @@ impl CoreBPE {
     }
 
     fn _encode_native(&self, text: &str, allowed_special: &HashSet<&str>) -> (Vec<usize>, usize) {
+        let special_regex = self._get_tl_special_regex();
+        let regex = self._get_tl_regex();
         let mut ret = vec![];
 
         let mut start = 0;
@@ -225,11 +241,8 @@ impl CoreBPE {
             let mut start_find = start;
             loop {
                 // Find the next allowed special token, if any
-                next_special = self
-                    .special_regex
-                    .find_at(text.as_bytes(), start_find)
-                    .unwrap();
-                match &next_special {
+                next_special = special_regex.find_from_pos(text, start_find).unwrap();
+                match next_special {
                     Some(m) => {
                         if allowed_special.contains(&text[m.start()..m.end()]) {
                             break;
@@ -239,13 +252,11 @@ impl CoreBPE {
                     None => break,
                 }
             }
-            let end: usize = next_special
-                // .as_ref()
-                .map_or(text.len(), |m| -> usize { m.start() });
+            let end = next_special.map_or(text.len(), |m| m.start());
 
             // Okay, here we go, compare this logic to _encode_ordinary_native
-            for mat in self.regex.find_iter(&text[start..end].as_bytes()) {
-                let piece = mat.unwrap().as_bytes();
+            for mat in regex.find_iter(&text[start..end]) {
+                let piece = mat.unwrap().as_str().as_bytes();
                 if let Some(token) = self.encoder.get(piece) {
                     last_piece_token_len = 1;
                     ret.push(*token);
@@ -259,10 +270,10 @@ impl CoreBPE {
             match next_special {
                 // And here we push the special token
                 Some(m) => {
-                    let piece = std::str::from_utf8(m.as_bytes()).unwrap();
+                    let piece = m.as_str();
                     let token = self.special_tokens_encoder[piece];
                     ret.push(token);
-                    start = m.start();
+                    start = m.end();
                     last_piece_token_len = 0;
                 }
                 None => break,
@@ -438,27 +449,17 @@ impl CoreBPE {
         special_tokens_encoder: HashMap<String, usize>,
         pattern: &str,
     ) -> PyResult<Self> {
-        let builder = {
-            let mut builder = RegexBuilder::new();
-            builder.jit_if_available(true);
-            builder
-        };
+        let regex = Regex::new(pattern)
+            .map_err(|e| PyErr::new::<exceptions::PyValueError, _>(e.to_string()))?;
 
-        fn pcre2_error_mapper(e: pcre2::Error) -> pyo3::PyErr {
-            PyErr::new::<exceptions::PyValueError, _>(e.to_string())
-        }
-
-        let regex = builder.build(pattern).map_err(pcre2_error_mapper)?;
-
-        let special_pattern = {
+        let special_regex = {
             let _parts = special_tokens_encoder
                 .keys()
                 .map(|s| fancy_regex::escape(s))
                 .collect::<Vec<_>>();
-            &_parts.join("|")
+            Regex::new(&_parts.join("|"))
+                .map_err(|e| PyErr::new::<exceptions::PyValueError, _>(e.to_string()))?
         };
-
-        let special_regex = builder.build(special_pattern).map_err(pcre2_error_mapper)?;
 
         let decoder: HashMap<usize, Vec<u8>> =
             encoder.iter().map(|(k, v)| (*v, k.clone())).collect();
@@ -479,8 +480,10 @@ impl CoreBPE {
             special_tokens_encoder,
             decoder,
             special_tokens_decoder,
-            regex: regex,
-            special_regex: special_regex,
+            regex_tls: (0..MAX_NUM_THREADS).map(|_| regex.clone()).collect(),
+            special_regex_tls: (0..MAX_NUM_THREADS)
+                .map(|_| special_regex.clone())
+                .collect(),
             sorted_token_bytes,
         })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,11 +22,16 @@ fn _byte_pair_merge<T>(
 
     // NOTE: using a macro here because a closure fails to get inlined
     // according to optimization remarks.
+    // A closure also cannot capture a reference to `piece` without
+    // the borrow checker complaining about the mutable borrows during
+    // the assignments later in this code.
     macro_rules! get_rank {
         ($start_idx:expr, $skip:expr) => {{
-            if ($start_idx + $skip + 2) < parts.len() {
+            let start_idx: usize = $start_idx;
+            let skip: usize = $skip;
+            if (start_idx + skip + 2) < parts.len() {
                 ranks
-                    .get(&piece[parts[$start_idx].0..parts[$start_idx + $skip + 2].0])
+                    .get(&piece[parts[start_idx].0..parts[start_idx + skip + 2].0])
                     .map(|r| *r)
             } else {
                 None

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,11 +10,53 @@ use pyo3::types::{PyBytes, PyList, PyTuple};
 use pyo3::PyResult;
 use rustc_hash::FxHashMap as HashMap;
 
-fn _byte_pair_merge(piece: &[u8], ranks: &HashMap<Vec<u8>, usize>) -> Vec<std::ops::Range<usize>> {
-    let mut parts: Vec<_> = (0..piece.len()).map(|i| i..i + 1).collect();
+fn _byte_pair_merge<T>(
+    piece: &[u8],
+    ranks: &HashMap<Vec<u8>, usize>,
+    f: impl Fn(std::ops::Range<usize>) -> T,
+) -> Vec<T> {
+    // This is a vector of (start, rank).
+    // The rank is of the byte pair starting at position start.
+    // The rank of the last item in the vector is not a valid value.
+    let mut parts: Vec<(usize, usize)> = (0..piece.len() + 1).map(|i| (i, usize::MAX)).collect();
 
-    // If you have n parts and m merges, this does O(mn) work
-    // We could do something with a heap and do O(m log n) work
+    // NOTE: using a macro here because a closure fails to get inlined
+    // according to optimization remarks.
+    macro_rules! get_rank {
+        ($start_idx:expr, $skip:expr) => {{
+            if ($start_idx + $skip + 2) < parts.len() {
+                ranks
+                    .get(&piece[parts[$start_idx].0..parts[$start_idx + $skip + 2].0])
+                    .map(|r| *r)
+            } else {
+                None
+            }
+        }};
+        ($idx:expr) => {{
+            get_rank!($idx, 0)
+        }};
+    }
+
+    // We look up the ranks once in the beggining and iteratively update
+    // them during each merge, which reduces the number of rank lookups.
+    for i in 0..parts.len() - 2 {
+        match get_rank!(i) {
+            Some(rank) => {
+                // usize::MAX is a sentinel value and cannot be a valid rank
+                debug_assert!(rank != usize::MAX);
+                parts[i].1 = rank;
+            }
+            None => {
+                continue;
+            }
+        };
+    }
+
+    // If you have n parts and m merges, this does O(mn) work.
+    // We could do something with a heap and do O(m log n) work.
+    // It is important to consider that n is often small (<100), and as such
+    // the cache-locality benefits outweigh the algorithmic complexity downsides
+    // of the `parts` vector data structure above.
 
     // Note that we hash bytes, not token pairs. As long as we train BPE the way we
     // currently do, this is equivalent. An easy way to break this would be to decouple
@@ -23,45 +65,53 @@ fn _byte_pair_merge(piece: &[u8], ranks: &HashMap<Vec<u8>, usize>) -> Vec<std::o
         if parts.len() == 1 {
             break;
         }
-        let mut min_rank: Option<(usize, usize)> = None;
-        for i in 0..parts.len() - 1 {
-            let rank = if let Some(r) = ranks.get(&piece[parts[i].start..parts[i + 1].end]) {
-                *r
-            } else {
-                continue;
-            };
-            if min_rank.is_none() || rank < min_rank.unwrap().0 {
-                min_rank = Some((rank, i));
+
+        // usize::MAX is a sentinel rank value allowing us to
+        // take the min more quickly
+        let mut min_rank: (usize, usize) = (usize::MAX, 0);
+        for (i, &(_, rank)) in parts[..parts.len() - 1].iter().enumerate() {
+            if rank < min_rank.0 {
+                min_rank = (rank, i);
             }
         }
-        if let Some((_, i)) = min_rank {
-            parts[i] = parts[i].start..parts[i + 1].end;
+
+        if min_rank.0 != usize::MAX {
+            let i = min_rank.1;
+
+            // NOTE: We are about to remove parts[i + 1]. We do not do it
+            // yet because there are cache-locality benefits to updating
+            // parts[i] and parts[i-1] before removing, which could thrash
+            // the cache. Thus, we update the rank calculation by skipping over
+            // parts[i + 1], by invoking `get_rank!` with `skip = 1`.
+            parts[i].1 = get_rank!(i, 1).unwrap_or(usize::MAX);
+            if i > 0 {
+                parts[i - 1].1 = get_rank!(i - 1, 1).unwrap_or(usize::MAX);
+            }
+
             parts.remove(i + 1);
         } else {
             break;
         }
     }
-    parts
+    let mut out: Vec<T> = Vec::with_capacity(parts.len() - 1);
+    for i in 0..parts.len() - 1 {
+        out.push(f(parts[i].0..parts[i + 1].0));
+    }
+    out
 }
 
 pub fn byte_pair_encode(piece: &[u8], ranks: &HashMap<Vec<u8>, usize>) -> Vec<usize> {
     if piece.len() == 1 {
         return vec![ranks[piece]];
     }
-    _byte_pair_merge(piece, ranks)
-        .iter()
-        .map(|p| ranks[&piece[p.start..p.end]])
-        .collect()
+    _byte_pair_merge(piece, ranks, |p| ranks[&piece[p.start..p.end]])
 }
 
 pub fn byte_pair_split<'a>(piece: &'a [u8], ranks: &HashMap<Vec<u8>, usize>) -> Vec<&'a [u8]> {
     if piece.len() == 1 {
         return vec![piece];
     }
-    _byte_pair_merge(piece, ranks)
-        .iter()
-        .map(|p| &piece[p.start..p.end])
-        .collect()
+    _byte_pair_merge(piece, ranks, |p| &piece[p.start..p.end])
 }
 
 // Various performance notes:


### PR DESCRIPTION
## TODO
The first commit of this PR has been reverted until @hauntsaninja can confirm PCRE2 behaves as expected.

## Summary
This PR contributes a 2x performance improvement via optimizations that I implemented this weekend.
It achieves this improvement by using PCRE2 for regex parsing and by changing `byte_pair_merge` to reduce rank lookups, reduce branching, and improve CPU-cache efficiency.

## List of changes
In particular, the improvements to `byte_pair_merge` are:
- Changing the `parts` vector to avoid repetition of data.
  
  This vector used to store ranges for which the invariant `parts[i].end == parts[i + 1].start` holds, which makes the vector twice as big as it needs to be.
  Keeping this vector small improves CPU-cache efficiency.
- Using `usize::MAX` as a sentinel in lieu of `Optional` for the computation of the minimum rank.
  
  This change removes branching from the loop to compute the minimum rank, generating assembly that uses conditional moves instead.

  Ideally, we could keep the `Optional` and inform it of the sentinel much like `Optional<NonZeroUsize>`. As far as I could tell, specifying custom sentinels for `Optional` has an old Rust [RFC](https://github.com/rust-lang/rfcs/pull/41) that has stalled, so we don't get to have nice things.
- Minimizing the number of lookups into `ranks` by looking up ranks once and iteratively updating them after each merge.

  This reduces the number of rank lookups from `n*m` to `n + O(m)`.
## Benchmarking

### Background
This [gist](https://gist.github.com/nistath/a7dc5b1b3ea8236b2cc30d1f16a257ac) contains supplemental information for the benchmarks I used.
Before collecting measurements, I quiesced my laptop (Intel i7-7700HQ @ 2.80GHz) by setting up isolcpus and following this [guide](https://easyperf.net/blog/2019/08/02/Perf-measurement-environment-on-Linux#2-disable-hyper-threading).
The benchmarks were run with `--reps 30`.

The only change my code makes to parallel performance is the thread local model for the regex parser. The PCRE2 library is mostly thread-safe and the `rust-pcre2` bindings crate I forked uses the `thread_local` crate for any scratch space used for regex matching. I have left notes on this in the diff.
I do not repeat the scaling measurements as I don't have that many cores, but I do one measurement to validate that the above difference doesn't play a big role.

### Datasets

Since the original benchmarking dataset is not available, I used two files: 64KB of Lorem Ipsum (`lorem_ipsum_64k.txt`) and 64K emojis (252KB) generated with `./emoji_gen.py 64000 > emojis.txt`. The Lorem Ipsum file and the script to generate random emoji sequences are available in the gist.

### Measurements

I compare 3 incremental versions of tiktoken: the original, the one with PCRE2 (commit 1), and the one with PCRE2 and my `byte_pair_merge` optimizations (commit 2).
The original version of tiktoken fails to complete `emojis.txt` and I gave up on waiting for it after a few minutes (compared to 24 ms for the version in this PR).

The following table shows the results in bytes per second as well as incremental speedups.

| encoding  | file                | cores | original | →      | commit 1 | →      | commit 2 | total speedup |
| --------- | ------------------- | ----- | -------- | ------ | -------- | ------ | -------- | ------------- |
| `gpt2`      | `lorem_ipsum_64k` | 1     | 4224157  | 75.11% | 7396769  | 40.83% | 10417089 | 2.47          |
| `r50k_base` | `lorem_ipsum_64k` | 1     | 4225109  | 76.48% | 7456639  | 36.46% | 10175065 | 2.41          |
| `gpt2`      | `lorem_ipsum_64k` | 4     | 14436023 | 54.91% | 22363385 | 27.29% | 28465609 | 1.97          |
| `gpt2`      | `emojis`          | 1     | 0        | ∞      | 10659178 | 2.38%  | 10912785 | ∞             |
| `r50k_base` | `emojis`          | 1     | 0        | ∞      | 10413159 | 3.10%  | 10736463 | ∞             |

With commit 1 reverted, the speedups are 15% for `lorem_ipsum_64k` and `emojis` terminates with a whopping 13933 bytes per second throughput. The speedups of commit 2 are more evident when the core bottleneck of regex is dealt with first, but they're still important in isolation.

## Testing
Since most of the tests are not available either, I simply ran both the original and my version against a bunch of text and ensured the outputs were the same.

## Discussion
I also briefly attempted using a heap, as suggested in the comments.
I quickly abandoned that approach because, as mentioned in the diff, `n = pieces.len()` is very small (usually less than 10) and as such it is more cache-efficient to just loop through a vector than it is to operate on a heap. This cache-efficiency vastly outweighs any algorithmic speedup.

Also, it is interesting to note that different datasets spend a different ratio of time between regex lookups and `byte_pair_merge`, with `lorem_ipsum_64k`.
In the original code on `lorem_ipsum_64k` the regex and `byte_pair_merge` took a roughly equal amount of time according to perf.
From the table above, it is evident that `emojis` is mostly bottlenecked on regex matching.
