### PR TITLE
adds gpt-3.5-turbo and prefix matching to encoding_for_model()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This is the changelog for the open source version of tiktoken.
 
+## [v0.2.1]
+- Add support for new `gpt-3.5-turbo` models
+- Add prefix matching to `encoding_for_model` to support future model versions
+
 ## [v0.2.0]
 - Add ``tiktoken.encoding_for_model`` to get the encoding for a specific model
 - Improve portability of caching logic

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiktoken"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 rust-version = "1.57.0"
 

--- a/tests/test_simple_public.py
+++ b/tests/test_simple_public.py
@@ -26,3 +26,5 @@ def test_encoding_for_model():
     assert enc.name == "p50k_base"
     enc = tiktoken.encoding_for_model("text-davinci-edit-001")
     assert enc.name == "p50k_edit"
+    enc = tiktoken.encoding_for_model("gpt-3.5-turbo-0301")
+    assert enc.name == "cl100k_base"

--- a/tiktoken/model.py
+++ b/tiktoken/model.py
@@ -3,8 +3,15 @@ from __future__ import annotations
 from .core import Encoding
 from .registry import get_encoding
 
-# TODO: this will likely be replaced by an API endpoint
+# TODO: these will likely be replaced by an API endpoint
+MODEL_PREFIX_TO_ENCODING: dict[str, str] = {
+    # chat
+    "gpt-3.5-turbo-": "cl100k_base",  # e.g, gpt-3.5-turbo-0301, -0401, etc.
+}
+
 MODEL_TO_ENCODING: dict[str, str] = {
+    # chat
+    "gpt-3.5-turbo": "cl100k_base",
     # text
     "text-davinci-003": "p50k_base",
     "text-davinci-002": "p50k_base",
@@ -45,6 +52,14 @@ MODEL_TO_ENCODING: dict[str, str] = {
 
 
 def encoding_for_model(model_name: str) -> Encoding:
+    """Returns the encoding used by a model."""
+    # first, check if the model matches a known prefix
+    # prefix matching avoids needing library updates for every model version release
+    # note that this can match on non-existent models (e.g., gpt-3.5-turbo-FAKE)
+    for model_prefix, model_encoding_name in MODEL_PREFIX_TO_ENCODING.items():
+        if model_name.startswith(model_prefix):
+            return get_encoding(model_encoding_name)
+    # otherwise, check if the model matches a known model name
     try:
         encoding_name = MODEL_TO_ENCODING[model_name]
     except KeyError:


### PR DESCRIPTION
Four changes:

- Registers `gpt-3.5-turbo` on the model list
- Adds prefix matching logic so that we can match on future versions of `gpt-3.5-turbo` without needing library updates (e.g., `gpt-3.5-turbo-0301`, `gpt-3.5-turbo-0401`); note that this means the function can now return encodings for non-existent models like `gpt-3.5-turbo-FAKE`, but seems well worth the tradeoff
- Adds a small test
- Increments the minor version number