### PR TITLE
Patch gpt-35-turbo mapping for Azure naming restrictions

### DIFF
--- a/tiktoken/model.py
+++ b/tiktoken/model.py
@@ -14,6 +14,7 @@ MODEL_TO_ENCODING: dict[str, str] = {
     # chat
     "gpt-4": "cl100k_base",
     "gpt-3.5-turbo": "cl100k_base",
+    "gpt-35-turbo": "cl100k_base", # making it compatible with Azure's naming restrictions
     # text
     "text-davinci-003": "p50k_base",
     "text-davinci-002": "p50k_base",


### PR DESCRIPTION
Adding `gpt-35-turbo` into mapping since Azure does not allow for `.` in the model name. `tiktoken` package is used by other packages e.g., [langchain](https://github.com/hwchase17/langchain/blob/master/langchain/chat_models/openai.py#L331). Patching this naming restrictions in tiktoken seems like the bext fix.