### PR TITLE
modify cache_dir permission on creation: RWX for all users

### DIFF
--- a/tiktoken/load.py
+++ b/tiktoken/load.py
@@ -45,7 +45,9 @@ def read_file_cached(blobpath: str) -> bytes:
 
     contents = read_file(blobpath)
 
-    os.makedirs(cache_dir, exist_ok=True)
+    if not os.path.exists(cache_dir):
+        os.makedirs(cache_dir, exist_ok=True)
+        os.chmod(cache_dir, 0o777) # available for all users ignoring umask
     tmp_filename = cache_path + "." + str(uuid.uuid4()) + ".tmp"
     with open(tmp_filename, "wb") as f:
         f.write(contents)


### PR DESCRIPTION
## Rationale

`os.makedirs` makes dirs with default mode 0o777 but it will be ignored by `umask`

Since all users use the same tmp dirs, it's reasonal for who creates the dir to make it available for all users.

It make this package more friendly for server users with poor group management.

references: 
- [os-offical](https://docs.python.org/3/library/os.html#os.makedirs)
- [stackoverflow](https://stackoverflow.com/questions/5231901/permission-problems-when-creating-a-dir-with-os-makedirs-in-python)

## Inspiration

Inspired by error here:
```
  File "/home/.../miniconda3/envs/gpt/lib/python3.10/site-packages/tiktoken/load.py", line 45, in read_file_cached
    with open(tmp_filename, "wb") as f:
PermissionError: [Errno 13] Permission denied: '/tmp/data-gym-cache/6d1cbeee0f20b3d9449abfede4726ed8212e3aee.ae9a214b-58de-415c-9e0a-024535f4f7a7.tmp'
```

Someone create the cache_dir and I don't have the writing permission in this cache_dir. Thought I can solve it by modifying the permission, I think it's better to be solved in the package.