### PR TITLE
update license metadata to use SPDX identifier as per recommendation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "tiktoken"
 version = "0.4.0"
 description = "tiktoken is a fast BPE tokeniser for use with OpenAI's models"
 readme = "README.md"
-license = {file = "LICENSE"}
+license = "MIT"
 authors = [{name = "Shantanu Jain"}, {email = "shantanu@openai.com"}]
 dependencies = ["regex>=2022.1.18", "requests>=2.26.0"]
 optional-dependencies = {blobfile = ["blobfile>=2"]}


### PR DESCRIPTION
This is a housekeeping code change suggestion. This project is released under the MIT license as per the `LICENSE` file's contents, however the current metadata notation makes handling that information harder than it should be.

The [PEP621's license field info](https://peps.python.org/pep-0621/#license) generally recommends using a [SPDX-compatible license identifier](https://spdx.org/licenses/), which in this case is "MIT". Before this proposed change, other tools that use metadata-extraction (such as [pip-licenses](https://github.com/raimon49/pip-licenses)) hiccups on the license value on this library, not being able to infer that it's the same license as many other projects as well.

Given how licensing applies, I believe this should be without downside and any loss of clarity or control on the side of the project's creators, while having definite (even if niche) upside for the project's users. Happy to bring in examples from other MIT-licensed projects that use the same format.