### PR TITLE
from __future__ import annotations to use dict for type annotation

### DIFF
--- a/tiktoken/_educational.py
+++ b/tiktoken/_educational.py
@@ -1,6 +1,6 @@
+"""This is an educational implementation of the byte pair encoding algorithm."""
 from __future__ import annotations
 
-"""This is an educational implementation of the byte pair encoding algorithm."""
 import collections
 import itertools
 from typing import Optional

--- a/tiktoken/_educational.py
+++ b/tiktoken/_educational.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """This is an educational implementation of the byte pair encoding algorithm."""
 import collections
 import itertools


### PR DESCRIPTION
Currently, the `_educational.py` is used with direct import, and uses `dict` for type annotation, which requires the `from __future__ import annotations` statement.