### PR TITLE
feat: Add option TIKTOKEN_FORCE_CACHE

### DIFF
--- a/tiktoken/load.py
+++ b/tiktoken/load.py
@@ -44,7 +44,9 @@ def read_file_cached(blobpath: str) -> bytes:
     if os.path.exists(cache_path):
         with open(cache_path, "rb") as f:
             return f.read()
-
+    elif os.environ.get("TIKTOKEN_FORCE_CACHE") == "1":
+        raise FileNotFoundError(f"Cache for: {blobpath} not found in tiktoken cache dir: {cache_dir}")
+    
     contents = read_file(blobpath)
 
     os.makedirs(cache_dir, exist_ok=True)


### PR DESCRIPTION
Add taking into account the env var TIKTOKEN_FORCE_CACHE. When TIKTOKEN_FORCE_CACHE is set to "1", tiktoken will read BPE files only from the local cache.

It allows us to have control over when BPE files are downloaded from the internet.