### PR TITLE
Allow option to load in encodings ref from local file path instead of external call

### DIFF
--- a/tiktoken/registry.py
+++ b/tiktoken/registry.py
@@ -61,7 +61,7 @@ def get_encoding(encoding_name: str, local_vocab_bpe_path: str = None, local_enc
 
         constructor = ENCODING_CONSTRUCTORS[encoding_name]
         if encoding_name == "gpt2":
-            enc = Encoding(**constructor(local_vocab_bpe_path = local_vocab_bpe_path, local_encoding_path=local_encoding_path))
+            enc = Encoding(**constructor(local_vocab_bpe_path=local_vocab_bpe_path, local_encoding_path=local_encoding_path))
         elif encoding_name == "cl100k_base":
             enc = Encoding(**constructor(local_encoding_path=local_encoding_path))
         else:

--- a/tiktoken/registry.py
+++ b/tiktoken/registry.py
@@ -44,7 +44,7 @@ def _find_constructors() -> None:
                 ENCODING_CONSTRUCTORS[enc_name] = constructor
 
 
-def get_encoding(encoding_name: str) -> Encoding:
+def get_encoding(encoding_name: str, local_vocab_bpe_path: str = None, local_encoding_path: str = None) -> Encoding:
     if encoding_name in ENCODINGS:
         return ENCODINGS[encoding_name]
 
@@ -60,7 +60,12 @@ def get_encoding(encoding_name: str) -> Encoding:
             raise ValueError(f"Unknown encoding {encoding_name}")
 
         constructor = ENCODING_CONSTRUCTORS[encoding_name]
-        enc = Encoding(**constructor())
+        if encoding_name == "gpt2":
+            enc = Encoding(**constructor(local_vocab_bpe_path = local_vocab_bpe_path, local_encoding_path=local_encoding_path))
+        elif encoding_name == "cl100k_base":
+            enc = Encoding(**constructor(local_encoding_path=local_encoding_path))
+        else:
+            enc = Encoding(**constructor())
         ENCODINGS[encoding_name] = enc
         return enc
 

--- a/tiktoken_ext/openai_public.py
+++ b/tiktoken_ext/openai_public.py
@@ -7,10 +7,18 @@ FIM_SUFFIX = "<|fim_suffix|>"
 ENDOFPROMPT = "<|endofprompt|>"
 
 
-def gpt2():
+def gpt2(local_vocab_bpe_path: str = None, local_encoding_path: str = None):
+    if local_vocab_bpe_path:
+        vocab_bpe_file = local_vocab_bpe_path
+    else:
+        vocab_bpe_file = "https://openaipublic.blob.core.windows.net/gpt-2/encodings/main/vocab.bpe"
+    if local_encoding_path:
+        encoder_json_file = local_encoding_path
+    else:
+        encoder_json_file = "https://openaipublic.blob.core.windows.net/gpt-2/encodings/main/encoder.json"
     mergeable_ranks = data_gym_to_mergeable_bpe_ranks(
-        vocab_bpe_file="https://openaipublic.blob.core.windows.net/gpt-2/encodings/main/vocab.bpe",
-        encoder_json_file="https://openaipublic.blob.core.windows.net/gpt-2/encodings/main/encoder.json",
+        vocab_bpe_file=vocab_bpe_file,
+        encoder_json_file=encoder_json_file,
     )
     return {
         "name": "gpt2",
@@ -60,10 +68,12 @@ def p50k_edit():
     }
 
 
-def cl100k_base():
-    mergeable_ranks = load_tiktoken_bpe(
-        "https://openaipublic.blob.core.windows.net/encodings/cl100k_base.tiktoken"
-    )
+def cl100k_base(local_encoding_path: str = None):
+    if local_encoding_path:
+        bpe_file = local_encoding_path
+    else:
+        bpe_file = "https://openaipublic.blob.core.windows.net/encodings/cl100k_base.tiktoken"
+    mergeable_ranks = load_tiktoken_bpe(bpe_file)
     special_tokens = {
         ENDOFTEXT: 100257,
         FIM_PREFIX: 100258,


### PR DESCRIPTION
This is to enable private network scenarios in AzureML RAG, where external public network calls (e.g. to _https://openaipublic.blob.core.windows.net_) will be restricted. In this case, we would refer tiktoken to use the encodings file from the image itself.