### PR TITLE
Support newer completion models in `encoding_for_model`

### DIFF
--- a/tiktoken/model.py
+++ b/tiktoken/model.py
@@ -17,6 +17,8 @@ MODEL_TO_ENCODING: dict[str, str] = {
     "gpt-3.5-turbo": "cl100k_base",
     "gpt-35-turbo": "cl100k_base",  # Azure deployment name
     # text
+    "davinci-002": "cl100k_base",
+    "babbage-002": "cl100k_base",
     "text-davinci-003": "p50k_base",
     "text-davinci-002": "p50k_base",
     "text-davinci-001": "r50k_base",


### PR DESCRIPTION
Adds the new completion models `davinci-002` and `babbage-002` to the mapping used in `encoding_for_model`.

I believe `"cl100k_base"` is the correct encoding for these models, based on the results from [this test](https://community.openai.com/t/tokenizers-for-davinci-002-and-babbage-002/327989/2?u=rob-galileo) I did. If that's not right, feel free to modify or close this.