### PR TITLE
Make `Encoding` serializable

### DIFF
--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -1,5 +1,6 @@
 # Note that there are more actual tests, they're just not currently public :-)
 
+import pickle
 from typing import Callable
 
 import hypothesis
@@ -229,3 +230,13 @@ def test_hyp_batch_roundtrip(make_enc: Callable[[], tiktoken.Encoding], batch):
     assert encoded == [enc.encode(t) for t in batch]
     decoded = enc.decode_batch(encoded)
     assert decoded == batch
+
+
+def test_serialization():
+    enc = tiktoken.get_encoding("gpt2")
+    enc2 = pickle.loads(pickle.dumps(enc))
+
+    assert enc.name == enc2.name
+    assert enc._pat_str == enc._pat_str
+    assert enc._special_tokens == enc._special_tokens
+    assert enc._mergeable_ranks == enc._mergeable_ranks

--- a/tiktoken/core.py
+++ b/tiktoken/core.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import functools
 from concurrent.futures import ThreadPoolExecutor
-from typing import AbstractSet, Collection, Literal, NoReturn, Optional, Union
+from typing import AbstractSet, Collection, Literal, NoReturn, Optional, Union, Callable
 
 import regex
 
@@ -51,6 +51,9 @@ class Encoding:
 
     def __repr__(self) -> str:
         return f"<Encoding {self.name!r}>"
+
+    def __reduce__(self) -> tuple[Callable[[], Encoding], tuple[()]]:
+        return functools.partial(Encoding, self.name, pat_str=self._pat_str, mergeable_ranks=self._mergeable_ranks, special_tokens=self._special_tokens), ()
 
     # ====================
     # Encoding


### PR DESCRIPTION
Thanks to https://github.com/karpathy/nanoGPT, many users use `tiktoken` with the `datasets` `map` method in the multi-process mode. However, `tiktoken.Encoding` currently doesn't support pickling (`_core_bpe` referencing a Rust binding object is the problem), which leads to serialization errors (see https://github.com/huggingface/datasets/issues/5536#issuecomment-1681820932 for the reproducer). This PR implements `titoken.Encoding.__reduce__` to fix this.