### PR TITLE
Improve `tiktoken.encoding_for_model` with better option

### DIFF
--- a/tiktoken/model.py
+++ b/tiktoken/model.py
@@ -15,6 +15,7 @@ MODEL_TO_ENCODING: dict[str, str] = {
     # chat
     "gpt-4": "cl100k_base",
     "gpt-3.5-turbo": "cl100k_base",
+    "gpt-3.5": "cl100k_base",  # Common shorthand
     "gpt-35-turbo": "cl100k_base",  # Azure deployment name
     # text
     "text-davinci-003": "p50k_base",
@@ -52,6 +53,7 @@ MODEL_TO_ENCODING: dict[str, str] = {
     "code-search-ada-code-001": "r50k_base",
     # open source
     "gpt2": "gpt2",
+    "gpt-2": "gpt2",  # Maintains consistency with gpt-4
 }
 
 


### PR DESCRIPTION
`tiktoken.encoding_for_model` is a convenient function for automatically selecting models. However, the following will result in an error:
```python
tiktoken.encoding_for_model("gpt-2")
tiktoken.encoding_for_model("gpt-3.5")
```

This is because the only available options right now are:
```python
tiktoken.encoding_for_model("gpt2")  # Notice the lack of dash
tiktoken.encoding_for_model("gpt-3.5-turbo")  # gpt-3.5 is a common shorthand here
```

This PR will allow the use of "gpt-2" and "gpt-3.5"