### PR TITLE
Replace `<|endoftext|>` with `ENDOFTEXT`

### DIFF
--- a/tiktoken_ext/openai_public.py
+++ b/tiktoken_ext/openai_public.py
@@ -17,7 +17,7 @@ def gpt2():
         "explicit_n_vocab": 50257,
         "pat_str": r"""'s|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+(?!\S)|\s+""",
         "mergeable_ranks": mergeable_ranks,
-        "special_tokens": {"<|endoftext|>": 50256},
+        "special_tokens": {ENDOFTEXT: 50256},
     }
 
 


### PR DESCRIPTION
Hi to whoever is reading this! 🤗 

## What's in this PR?

In the GPT2 configuration, the `special_tokens` include `<|endoftext|>`, while the pre-defined constant should be used instead, defined some lines above. So on, this PR just replaces `<|endoftext|>` with the constant `ENDOFTEXT`.