### PR TITLE
add __version__ attribute

### DIFF
--- a/tiktoken/__init__.py
+++ b/tiktoken/__init__.py
@@ -2,3 +2,4 @@ from .core import Encoding as Encoding
 from .model import encoding_for_model as encoding_for_model
 from .registry import get_encoding as get_encoding
 from .registry import list_encoding_names as list_encoding_names
+from .version import __version__

--- a/tiktoken/version.py
+++ b/tiktoken/version.py
@@ -1,0 +1,10 @@
+try:
+    import importlib.metadata as importlib_metadata
+except ImportError:
+    # Running on pre-3.8 Python; use importlib-metadata package
+    import importlib_metadata
+
+try:
+    __version__ = importlib_metadata.version("tiktoken")
+except Exception:
+    __version__ = "unknown"


### PR DESCRIPTION
Adds a `__version__`, attribute, for instance:

```python
In [1]: import tiktoken

In [2]: tiktoken.__version__
Out[2]: '0.5.0'
```

Tested it locally and it works on my machine.

Fixes #190