### PR TITLE
replace requests with httpx

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "tiktoken is a fast BPE tokeniser for use with OpenAI's models"
 readme = "README.md"
 license = {file = "LICENSE"}
 authors = [{name = "Shantanu Jain"}, {email = "shantanu@openai.com"}]
-dependencies = ["regex>=2022.1.18", "requests>=2.26.0"]
+dependencies = ["regex>=2022.1.18", "httpx"]
 optional-dependencies = {blobfile = ["blobfile>=2"]}
 requires-python = ">=3.8"
 

--- a/tiktoken/load.py
+++ b/tiktoken/load.py
@@ -7,7 +7,7 @@ import os
 import tempfile
 import uuid
 
-import requests
+import httpx
 
 
 def read_file(blobpath: str) -> bytes:
@@ -21,7 +21,7 @@ def read_file(blobpath: str) -> bytes:
         with blobfile.BlobFile(blobpath, "rb") as f:
             return f.read()
     # avoiding blobfile for public files helps avoid auth issues, like MFA prompts
-    resp = requests.get(blobpath)
+    resp = httpx.get(blobpath)
     resp.raise_for_status()
     return resp.content
 


### PR DESCRIPTION
[HTTPX](https://www.python-httpx.org) is a HTTP client for Python 3, that seamlessly supports both synchronous and asynchronous workflows. [The API is broadly compatible with `requests`](https://www.python-httpx.org/compatibility/), but it's entirely rebuilt; it shares no dependencies at all with `requests`.

Tiktoken requires Python 3.8 or higher, so the fact that HTTPX only supports Python 3 is not a problem. It also means that the developers who use `tiktoken` may want to take advantage of syntax and features that are only present in Python 3, like async support. Currently, `tiktoken` pulls in `requests` as a dependency even if the developer would prefer to use `httpx` for their application code -- which is not terrible, but more dependencies means more to download, slower CI execution, and a potentially larger attack surface from a security perspective.

Of course, the opposite would also be true for this pull request: if `tiktoken` pulls in `httpx` as a dependency, and the developer would prefer to use `requests` for their application code, we have the same problem. We could specify both `requests` and `httpx` as optional dependencies, and use whichever one we manage to import successfully; but that would make the code more complex, and could confuse developers who don't realize that they _must_ install one or the other of these optional dependencies in order to use `tiktoken`. As a result, I decided to start with a pull request suggesting the simplest possible change: directly swapping `requests` for `httpx`.

Please let me know what you think of this idea! I'm happy to alter this pull request in response to feedback.