### PR TITLE
Use a fresh tempdir for data-gym-cache to avoid "Permission denied"

### DIFF
--- a/tiktoken/load.py
+++ b/tiktoken/load.py
@@ -32,7 +32,7 @@ def read_file_cached(blobpath: str) -> bytes:
     elif "DATA_GYM_CACHE_DIR" in os.environ:
         cache_dir = os.environ["DATA_GYM_CACHE_DIR"]
     else:
-        cache_dir = os.path.join(tempfile.gettempdir(), "data-gym-cache")
+        cache_dir = tempfile.mkdtemp(prefix="tiktoken-cache")
 
     if cache_dir == "":
         # disable caching


### PR DESCRIPTION
See https://github.com/openai/tiktoken/issues/75#issuecomment-1810255745.  (Fixes #75)