### PR TITLE
added two new embedding model's encoding

### DIFF
--- a/tiktoken/model.py
+++ b/tiktoken/model.py
@@ -26,6 +26,8 @@ MODEL_TO_ENCODING: dict[str, str] = {
     "babbage-002": "cl100k_base",
     # embeddings
     "text-embedding-ada-002": "cl100k_base",
+    "text-embedding-3-small": "cl100k_base",
+    "text-embedding-3-large": "cl100k_base",
     # DEPRECATED MODELS
     # text (DEPRECATED)
     "text-davinci-003": "p50k_base",


### PR DESCRIPTION
**Problem**
Library doesn't support two new embedding model's encoding mapper
- `text-embedding-3-small`
- `text-embedding-3-large`

`tiktoken.encoding_for_model("text-embedding-3-small") ` raises a **KeyError**

<img width="1327" alt="Screenshot 2024-01-27 at 1 08 05 AM" src="https://github.com/openai/tiktoken/assets/23660137/fae6b8ed-434b-4ccc-bd8b-63e25f5d776d">

**Solution**
Added Encoding mapper for 2 new embedding models. The source of mapping is taken from [here](https://github.com/openai/openai-cookbook/blob/main/examples/How_to_count_tokens_with_tiktoken.ipynb)

