### PR TITLE
Add turbo 16k model for Azure

### DIFF
--- a/tiktoken/model.py
+++ b/tiktoken/model.py
@@ -22,6 +22,7 @@ MODEL_TO_ENCODING: dict[str, str] = {
     "gpt-3.5-turbo": "cl100k_base",
     "gpt-3.5": "cl100k_base",  # Common shorthand
     "gpt-35-turbo": "cl100k_base",  # Azure deployment name
+    "gpt-35-turbo-16k": "cl100k_base",  # Azure deployment name for 16k token context model
     # base
     "davinci-002": "cl100k_base",
     "babbage-002": "cl100k_base",


### PR DESCRIPTION
Azure OpenAI service allows us to deploy 16k token context version of gpt-turbo-3.5 model which has the name as **gpt-35-turbo-16k**.