### PR TITLE
Remove dependency on requests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "tiktoken is a fast BPE tokeniser for use with OpenAI's models"
 readme = "README.md"
 license = {file = "LICENSE"}
 authors = [{name = "Shantanu Jain"}, {email = "shantanu@openai.com"}]
-dependencies = ["regex>=2022.1.18", "requests>=2.26.0"]
+dependencies = ["regex>=2022.1.18"]
 optional-dependencies = {blobfile = ["blobfile>=2"]}
 requires-python = ">=3.8"
 

--- a/tiktoken/load.py
+++ b/tiktoken/load.py
@@ -8,7 +8,7 @@ import tempfile
 import uuid
 from typing import Optional
 
-import requests
+import urllib.request
 
 
 def read_file(blobpath: str) -> bytes:
@@ -22,9 +22,9 @@ def read_file(blobpath: str) -> bytes:
         with blobfile.BlobFile(blobpath, "rb") as f:
             return f.read()
     # avoiding blobfile for public files helps avoid auth issues, like MFA prompts
-    resp = requests.get(blobpath)
-    resp.raise_for_status()
-    return resp.content
+    with urllib.request.urlopen(blobpath) as response:
+        resp = response.read()
+    return resp
 
 
 def check_hash(data: bytes, expected_hash: str) -> bool:


### PR DESCRIPTION
This PR swaps `requests` for Python's built-in `urllib.request` library, reducing the library size a decent amount.

Would you consider a PR doing something like this? Happy to make alterations.