### PR TITLE
DOC: Add a link toward PyPI tiktoken package.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ assert enc.decode(enc.encode("hello world")) == "hello world"
 enc = tiktoken.encoding_for_model("gpt-4o")
 ```
 
-The open source version of `tiktoken` can be installed from PyPI:
+The open source version of `tiktoken` can be installed from [PyPI](https://pypi.org/project/tiktoken):
 ```
 pip install tiktoken
 ```


### PR DESCRIPTION
Just adding a direct link toward https://pypi.org/project/tiktoken in the README file.

Sometimes, it can be interesting to find the package on PyPI to find some key info.
It is just a small modification, feel free to discard the PR.