### PR TITLE
Cache for Encoding - Runtime Boosted by 12%

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,14 +185,25 @@ impl CoreBPE {
     fn _encode_ordinary_native(&self, text: &str) -> Vec<Rank> {
         // This is the core of the encoding logic; the other functions in here
         // just make things complicated :-)
+
+        // The cache is a HashMap, populated first with encoder items, but keys are strings.
+        // The 0.05 ratio is experimental
+        let initial_capacity = (text.len() as f64 * 0.05) as usize;
+        let mut cache: HashMap<&str, Vec<Rank>> = HashMap::with_capacity_and_hasher(initial_capacity, Default::default());
+
+        for (k, &v) in self.encoder.iter() {
+            if let Ok(key_str) = std::str::from_utf8(k) {
+                cache.insert(key_str, vec![v]);
+            }
+        }
+
+        //lookup piece in cache, and add it if it is a nonekey
         let regex = self._get_tl_regex();
         let mut ret = vec![];
         for mat in regex.find_iter(text) {
-            let piece = mat.unwrap().as_str().as_bytes();
-            match self.encoder.get(piece) {
-                Some(token) => ret.push(*token),
-                None => ret.extend(&byte_pair_encode(piece, &self.encoder)),
-            }
+            let piece = mat.unwrap().as_str();
+            let encoded_tokens = cache.entry(piece).or_insert_with(|| byte_pair_encode(&piece.as_bytes(), &self.encoder));
+            ret.extend(&*encoded_tokens);
         }
         ret
     }


### PR DESCRIPTION
This PR introduces a caching mechanism in `_encode_ordinary_native()`, which stores the tokens for each "piece" of text. When a piece of text is repeated, its tokens are retrieved from the cache instead of being tokenized again.

This results in a runtime improvement of over 12% (from 20.21s to 17.96s on a single CPU core) when encoding 100MB of Linux source code as a single text.

The cache hit ratio is very high, approximately 95%. The final cache size is only 0.5% of the total number of pieces (218,450 vs. 39,769,721).

**TODO:**
- Despite the 95% cache hit ratio, the expected runtime boost was not fully realized. This is because 80% of the loop runtime in the current code is spent splitting the text using `regex`. While this PR makes the tokenization logic 65% faster, the BIG gain can be achieved by optimizing the text splitting, possibly through multithreading.
- Investigate declaring the cache in the `struct CoreBPE` so that it can be utilized across subsequent calls.