### PR TITLE
fix: add encoding for fine-tuned models based on gpt-4o

### DIFF
--- a/tiktoken/model.py
+++ b/tiktoken/model.py
@@ -11,6 +11,7 @@ MODEL_PREFIX_TO_ENCODING: dict[str, str] = {
     "gpt-3.5-turbo-": "cl100k_base",  # e.g, gpt-3.5-turbo-0301, -0401, etc.
     "gpt-35-turbo-": "cl100k_base",  # Azure deployment name
     # fine-tuned
+    "ft:gpt-4o": "o200k_base",
     "ft:gpt-4": "cl100k_base",
     "ft:gpt-3.5-turbo": "cl100k_base",
     "ft:davinci-002": "cl100k_base",


### PR DESCRIPTION
The encoding is different for gpt-4o than gpt-4 models. The current implementation matches `"ft:gpt-4": "cl100k_base"` in the `MODEL_PREFIX_TO_ENCODING` dictionary for fined-tuned models based on gpt-4o.