### PR TITLE
Build wheels for Python 3.13

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -16,7 +16,7 @@ jobs:
         # cibuildwheel builds linux wheels inside a manylinux container
         # it also takes care of procuring the correct python version for us
         os: [ubuntu-latest, windows-latest, macos-13]
-        python-version: [38, 39, 310, 311, 312]
+        python-version: [38, 39, 310, 311, 312, 313]
 
     steps:
       - uses: actions/checkout@v4
@@ -24,6 +24,7 @@ jobs:
       - uses: pypa/cibuildwheel@v2.18.0
         env:
           CIBW_BUILD: "cp${{ matrix.python-version}}-*"
+          CIBW_PRERELEASE_PYTHONS: True
 
       - uses: actions/upload-artifact@v3
         with:
@@ -37,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [38, 39, 310, 311, 312]
+        python-version: [38, 39, 310, 311, 312, 313]
 
     steps:
       - uses: actions/checkout@v4
@@ -55,6 +56,7 @@ jobs:
           CIBW_BUILD_VERBOSITY: 3
           # https://github.com/rust-lang/cargo/issues/10583
           CIBW_ENVIRONMENT_LINUX: PATH="$PATH:$HOME/.cargo/bin" CARGO_NET_GIT_FETCH_WITH_CLI=true
+          CIBW_PRERELEASE_PYTHONS: True
       - uses: actions/upload-artifact@v3
         with:
           name: dist

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ name = "_tiktoken"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.20.0", features = ["extension-module"] }
+pyo3 = { version = "0.22.0", features = ["extension-module", "gil-refs"] }
 
 # tiktoken dependencies
 fancy-regex = "0.11.0"


### PR DESCRIPTION
Hi! With python 3.13 coming out (hopefully) later today, it would be nice to have wheels for the new version available.

This PR adds Python 3.13 to the versions for which tiktoken should be built (for now together with `CIBW_PRERELEASE_PYTHONS: True`, since only `3.13.0rc2` is available to date). It also bumps `pyo3` to version `0.22` which supports Python 3.13, together with the `gil-refs` feature flag for backwards compatibility.

I suppose a discussion could be had about whether support for Python 3.8 should be dropped due to its end-of-life, but that's for another day.

Let me know if there's anything else that should be accounted for, my experience with Rust is very limited :)