### PR TITLE
Option to use TIKTOKEN_BPE_HOST environment variable for configurable BPE host URL

### DIFF
--- a/tiktoken_ext/openai_public.py
+++ b/tiktoken_ext/openai_public.py
@@ -1,4 +1,6 @@
 from tiktoken.load import data_gym_to_mergeable_bpe_ranks, load_tiktoken_bpe
+import os
+
 
 ENDOFTEXT = "<|endoftext|>"
 FIM_PREFIX = "<|fim_prefix|>"
@@ -13,11 +15,13 @@ r50k_pat_str = (
     r"""'(?:[sdmt]|ll|ve|re)| ?\p{L}++| ?\p{N}++| ?[^\s\p{L}\p{N}]++|\s++$|\s+(?!\S)|\s"""
 )
 
+TIKTOKEN_BPE_HOST = os.environ.get("TIKTOKEN_BPE_HOST", "https://openaipublic.blob.core.windows.net")
+
 
 def gpt2():
     mergeable_ranks = data_gym_to_mergeable_bpe_ranks(
-        vocab_bpe_file="https://openaipublic.blob.core.windows.net/gpt-2/encodings/main/vocab.bpe",
-        encoder_json_file="https://openaipublic.blob.core.windows.net/gpt-2/encodings/main/encoder.json",
+        vocab_bpe_file=f"{TIKTOKEN_BPE_HOST}/gpt-2/encodings/main/vocab.bpe",
+        encoder_json_file=f"{TIKTOKEN_BPE_HOST}/gpt-2/encodings/main/encoder.json",
         vocab_bpe_hash="1ce1664773c50f3e0cc8842619a93edc4624525b728b188a9e0be33b7726adc5",
         encoder_json_hash="196139668be63f3b5d6574427317ae82f612a97c5d1cdaf36ed2256dbf636783",
     )
@@ -32,7 +36,7 @@ def gpt2():
 
 def r50k_base():
     mergeable_ranks = load_tiktoken_bpe(
-        "https://openaipublic.blob.core.windows.net/encodings/r50k_base.tiktoken",
+        f"{TIKTOKEN_BPE_HOST}/encodings/r50k_base.tiktoken",
         expected_hash="306cd27f03c1a714eca7108e03d66b7dc042abe8c258b44c199a7ed9838dd930",
     )
     return {
@@ -46,7 +50,7 @@ def r50k_base():
 
 def p50k_base():
     mergeable_ranks = load_tiktoken_bpe(
-        "https://openaipublic.blob.core.windows.net/encodings/p50k_base.tiktoken",
+        f"{TIKTOKEN_BPE_HOST}/encodings/p50k_base.tiktoken",
         expected_hash="94b5ca7dff4d00767bc256fdd1b27e5b17361d7b8a5f968547f9f23eb70d2069",
     )
     return {
@@ -60,7 +64,7 @@ def p50k_base():
 
 def p50k_edit():
     mergeable_ranks = load_tiktoken_bpe(
-        "https://openaipublic.blob.core.windows.net/encodings/p50k_base.tiktoken",
+        f"{TIKTOKEN_BPE_HOST}/encodings/p50k_base.tiktoken",
         expected_hash="94b5ca7dff4d00767bc256fdd1b27e5b17361d7b8a5f968547f9f23eb70d2069",
     )
     special_tokens = {ENDOFTEXT: 50256, FIM_PREFIX: 50281, FIM_MIDDLE: 50282, FIM_SUFFIX: 50283}
@@ -74,7 +78,7 @@ def p50k_edit():
 
 def cl100k_base():
     mergeable_ranks = load_tiktoken_bpe(
-        "https://openaipublic.blob.core.windows.net/encodings/cl100k_base.tiktoken",
+        f"{TIKTOKEN_BPE_HOST}/encodings/cl100k_base.tiktoken",
         expected_hash="223921b76ee99bde995b7ff738513eef100fb51d18c93597a113bcffe865b2a7",
     )
     special_tokens = {
@@ -94,7 +98,7 @@ def cl100k_base():
 
 def o200k_base():
     mergeable_ranks = load_tiktoken_bpe(
-        "https://openaipublic.blob.core.windows.net/encodings/o200k_base.tiktoken",
+        f"{TIKTOKEN_BPE_HOST}/encodings/o200k_base.tiktoken",
         expected_hash="446a9538cb6c348e3516120d7c08b09f57c36495e2acfffe59a5bf8b0cfb1a2d",
     )
     special_tokens = {ENDOFTEXT: 199999, ENDOFPROMPT: 200018}


### PR DESCRIPTION
Replaced the hardcoded URL `https://openaipublic.blob.core.windows.net` with the `TIKTOKEN_BPE_HOST` environment variable, allowing for flexibility in sourcing BPE data. 

This change is particularly beneficial for environments where external access is restricted, such as private VPCs, or where organizations prefer using private/internal artifact repositories to pull dependencies. With this update, users can specify their own host URL for BPE data via `TIKTOKEN_BPE_HOST`, ensuring compatibility with network policies and internal infrastructure.

Additionally, it helps resolve SSL certificate verification errors like:

```
requests.exceptions.SSLError: HTTPSConnectionPool(host='openaipublic.blob.core.windows.net', port=443): Max retries exceeded with url: /encodings/cl100k_base.tiktoken (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self-signed certificate in certificate chain (_ssl.c:1007)')))
```

By allowing the BPE host URL to be set internally, this change supports environments using private artifact repositories, ensuring seamless access to required files without SSL-related interruptions.