### PR TITLE
Add gpt-4.1 to model

### DIFF
--- a/tiktoken/model.py
+++ b/tiktoken/model.py
@@ -10,6 +10,7 @@ MODEL_PREFIX_TO_ENCODING: dict[str, str] = {
     # chat
     "chatgpt-4o-": "o200k_base",
     "gpt-4o-": "o200k_base",  # e.g., gpt-4o-2024-05-13
+    "gpt-4.1-": "o200k_base", # e.g., gpt-4.1-2025-04-14
     "gpt-4-": "cl100k_base",  # e.g., gpt-4-0314, etc., plus gpt-4-32k
     "gpt-3.5-turbo-": "cl100k_base",  # e.g, gpt-3.5-turbo-0301, -0401, etc.
     "gpt-35-turbo-": "cl100k_base",  # Azure deployment name
@@ -27,6 +28,7 @@ MODEL_TO_ENCODING: dict[str, str] = {
     "o3": "o200k_base",
     # chat
     "gpt-4o": "o200k_base",
+    "gpt-4.1": "o200k_base",
     "gpt-4": "cl100k_base",
     "gpt-3.5-turbo": "cl100k_base",
     "gpt-3.5": "cl100k_base",  # Common shorthand


### PR DESCRIPTION
Tested gpt-4o and gpt-4.1 in the playground, and they seemed to use the same tokenizer because of the token count.