### PR TITLE
Add o4 model prefix to MODEL_PREFIX_TO_ENCODING  and MODEL_TO_ENCODING

### DIFF
--- a/tiktoken/model.py
+++ b/tiktoken/model.py
@@ -7,6 +7,7 @@ from .registry import get_encoding
 MODEL_PREFIX_TO_ENCODING: dict[str, str] = {
     "o1-": "o200k_base",
     "o3-": "o200k_base",
+    "o4-": "o200k_base",
     # chat
     "chatgpt-4o-": "o200k_base",
     "gpt-4o-": "o200k_base",  # e.g., gpt-4o-2024-05-13
@@ -25,6 +26,7 @@ MODEL_TO_ENCODING: dict[str, str] = {
     # reasoning
     "o1": "o200k_base",
     "o3": "o200k_base",
+    "o4": "o200k_base",
     # chat
     "gpt-4o": "o200k_base",
     "gpt-4": "cl100k_base",


### PR DESCRIPTION
Adds for the `o4-` to the `MODEL_PREFIX_TO_ENCODING` dictionary and `o4` to `MODEL_TO_ENCODING`. `4.1` has been added in [another PR ](https://github.com/openai/tiktoken/pull/396)