### PR TITLE
Add back in musllinux_aarch64 fix #350

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ skip = [
   "*-manylinux_i686",
   "*-musllinux_i686",
   "*-win32",
-  "*-musllinux_aarch64",
 ]
 macos.archs = ["x86_64", "arm64"]
 # When cross-compiling on Intel, it is not possible to test arm64 wheels.


### PR DESCRIPTION
Due to the way these heavier processes work it may crash the first time it tries to build, presumably because it scedules all of them on the same node. If you manually replay the ones that failed one at a time it will succeed.