### PR TITLE
Upgrade pyo3 to 0.24

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ python = [
 ]
 
 [dependencies]
-pyo3 = { version = "0.22.2", default-features = false, features = [
+pyo3 = { version = "0.24", default-features = false, features = [
     "extension-module",
     "macros",
 ], optional = true }


### PR DESCRIPTION
As per the title, simple upgrade to `pyo3 = 0.24`