### PR TITLE
bump PyO3 version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ python = [
 ]
 
 [dependencies]
-pyo3 = { version = "0.24.1", default-features = false, features = [
+pyo3 = { version = "0.25.1", default-features = false, features = [
     "extension-module",
     "macros",
 ], optional = true }


### PR DESCRIPTION
This allows supporting Python 3.14. I'll set that up in a followup once this is merged.