### PR TITLE
load.read_file: do not use blobfile for local files

### DIFF
--- a/tiktoken/load.py
+++ b/tiktoken/load.py
@@ -6,6 +6,10 @@ import os
 
 
 def read_file(blobpath: str) -> bytes:
+    if os.path.exists(blobpath):
+        with open(blobpath, "rb") as f:
+            return f.read()
+
     if not blobpath.startswith("http://") and not blobpath.startswith("https://"):
         try:
             import blobfile


### PR DESCRIPTION

If files are local, there's no need to go through the (optional) `blobfile` dependency, we can just read them using the standard `open`/`read` API.

This solves some issues when trying to load files that have already been downloaded to the HF cache.

See for example https://github.com/vllm-project/vllm/issues/21750
