### PR TITLE
Add instructions for developer installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,18 @@ setup(
 Then simply `pip install ./my_tiktoken_extension` and you should be able to use your
 custom encodings! Make sure **not** to use an editable install.
 
+## Development and Contributing
+
+To install `tiktoken` from source or build locally, you will need to install the Rust toolchain.
+Instructions for installing Rust can be found [here](https://rust-lang.org/tools/install/). For
+most Linux and Mac OS X installations, this can be done with:
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+```
+
+Once you have installed Rust, you may build the package using `pip`:
+
+```python
+pip install -e .
+```


### PR DESCRIPTION
Howdy,

   Installation from source (for development purposes using `pip install -e .` fails if the Rust compiler is not previously installed. While the code is clearly written partially in Rust, it was not clear from the README that the Rust toolchain is a dependency. I've added a section to the README to highlight the dependency and link to the Rust installation instructions.

Cheers,
   Eric