### PR TITLE
Update license information in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,8 @@ name = "tiktoken"
 version = "0.12.0"
 description = "tiktoken is a fast BPE tokeniser for use with OpenAI's models"
 readme = "README.md"
-license = { file = "LICENSE" }
+license = "MIT"
+license-files = ["LICENSE"]
 authors = [{ name = "Shantanu Jain" }, { email = "shantanu@openai.com" }]
 dependencies = ["regex", "requests"]
 optional-dependencies = { blobfile = ["blobfile>=3"] }


### PR DESCRIPTION
Make the licensing of the project PEP 639 compatible.

See [the user guide][user-guide], [respective PEP][pep-639], and [the support in `setuptools`][setuptools].

[user-guide]: https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files
[pep-639]: https://peps.python.org/pep-0639/
[setuptools]: https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html#setuptools-specific-configuration

Closes #125.
Fixes #362.