### PR TITLE
Initialize _special_token_values in Encoding.__init__

### DIFF
--- a/tiktoken/core.py
+++ b/tiktoken/core.py
@@ -51,6 +51,7 @@ class Encoding:
             assert len(mergeable_ranks) + len(special_tokens) == explicit_n_vocab
             assert self.max_token_value == explicit_n_vocab - 1
 
+        self._special_token_values = set(special_tokens.values())
         self._core_bpe = _tiktoken.CoreBPE(mergeable_ranks, special_tokens, pat_str)
 
     def __repr__(self) -> str:


### PR DESCRIPTION
The is_special_token method references self._special_token_values, but that attribute was never initialized, causing an AttributeError. Add initialization as a set built from special_tokens.values() in `__init__`.

Fixes the following issue:
```
Traceback (most recent call last):
  File "tiktoken/core.py", line 367, in is_special_token
    return token in self._special_token_values
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'Encoding' object has no attribute '_special_token_values'. Did you mean: '_special_tokens'?
```