### PR TITLE
Add support for building and testing tiktoken on Windows ARM64

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -16,8 +16,13 @@ jobs:
       matrix:
         # cibuildwheel builds linux wheels inside a manylinux container
         # it also takes care of procuring the correct python version for us
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest, windows-11-arm]
         python-version: [39, 310, 311, 312, 313, 313t, 314, 314t]
+        exclude:
+          - os: windows-11-arm
+            python-version: 39
+          - os: windows-11-arm
+            python-version: 310
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
**PR Description:**
- Installing tiktoken via PIP distribution on Windows ARM64 currently fails due to unavailability of tiktoken wheels for Windows ARM64 architecture.
- Due to the above issue, many users may not be able to use tiktoken library natively on Windows ARM64.
- To resolve this issue, this PR adds CI support for building and testing tiktoken on Windows ARM64.

**Changes Proposed:**
- Added Windows ARM64 build configurations in the workflow file[workflows/[build_wheels.yml](https://github.com/openai/tiktoken/compare/main...MugundanMCW:tiktoken:main#diff-52d0610b43ce35e44510ae2d15d70668334378b01c1bdc774159cd3a33b71728)].

**Installation logs:**
[logs.txt](https://github.com/user-attachments/files/25834086/logs.txt)
