### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: pypa/cibuildwheel@v3.1.4
+      - uses: pypa/cibuildwheel@v3.4.0
         env:
           CIBW_BUILD: "cp${{ matrix.python-version}}-*"
           CIBW_ENABLE: cpython-freethreading
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.1.4
+        uses: pypa/cibuildwheel@v3.4.0
         env:
           CIBW_BUILD: "cp${{ matrix.python-version}}-*"
           CIBW_ARCHS: aarch64
@@ -89,7 +89,7 @@ jobs:
     needs: [build_wheels, build_wheels_aarch64, build_sdist]
     steps:
      - name: Merge artifacts
-       uses: actions/upload-artifact/merge@v4
+       uses: actions/upload-artifact/merge@v7
        with:
          name: cibw-wheels
          pattern: cibw-wheels-*


### PR DESCRIPTION
Bumps GitHub Actions to their latest versions for bug fixes and security patches.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/upload-artifact/merge` | [`v4`](https://github.com/actions/upload-artifact/merge/releases/tag/v4) | [`v7`](https://github.com/actions/upload-artifact/merge/releases/tag/v7) | [Release](https://github.com/actions/upload-artifact/merge/releases/tag/v7) | build_wheels.yml |
| `pypa/cibuildwheel` | [`v3.1.4`](https://github.com/pypa/cibuildwheel/releases/tag/v3.1.4) | [`v3.4.0`](https://github.com/pypa/cibuildwheel/releases/tag/v3.4.0) | [Release](https://github.com/pypa/cibuildwheel/releases/tag/v3.4.0) | build_wheels.yml |

## Breaking Changes

- **actions/upload-artifact/merge** (v4 → v7): Major version upgrade — review the [release notes](https://github.com/actions/upload-artifact/releases) for breaking changes

## Notes

Worth running the workflows on a branch before merging to make sure everything still works.
