### PR TITLE
Add support for armv7l wheel building

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -83,7 +83,6 @@ jobs:
           CIBW_BUILD: "cp${{ matrix.python-version}}-*"
           CIBW_SKIP: "*-musllinux_armv7l"
           CIBW_ARCHS_LINUX: armv7l
-          CIBW_ALLOW_EMPTY: "1"
           CIBW_BUILD_VERBOSITY: 3
           CIBW_ENVIRONMENT_LINUX: PATH="$PATH:$HOME/.cargo/bin" CARGO_NET_GIT_FETCH_WITH_CLI=true
           CIBW_ENABLE: cpython-freethreading


### PR DESCRIPTION
This PR adds CI support for building `armv7l` (32-bit ARM) Python wheels via QEMU, which eliminates the need to compile from source for users on Raspberry Pi (#86), various SBCs lacking system package managers for Rust toolchain support (e.g. embedded devices using `buildroot`).

**Testing:**
- Successfully tested the workflow on my fork. 
- The `armv7l` wheel building job completes in approximately *15 minutes*.