### PR TITLE
ci: add riscv64 wheel builds

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -70,15 +70,15 @@ jobs:
         python-version: [310, 311, 312, 313, 313t, 314, 314t]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
         with:
           platforms: linux/riscv64
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.1.4
+        uses: pypa/cibuildwheel@65b8265957fd86372d9689a0acdfd55813970d5d # v3.1.4
         env:
           CIBW_BUILD: "cp${{ matrix.python-version}}-*"
           CIBW_ARCHS: riscv64
@@ -87,7 +87,7 @@ jobs:
           CIBW_ENVIRONMENT_LINUX: PATH="$PATH:$HOME/.cargo/bin" CARGO_NET_GIT_FETCH_WITH_CLI=true
           CIBW_ENABLE: cpython-freethreading
 
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: cibw-wheels-riscv64-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -60,6 +60,38 @@ jobs:
           name: cibw-wheels-aarch64-${{ matrix.os }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl
 
+  build_wheels_riscv64:
+    name: py${{ matrix.python-version }} on ubuntu-latest (riscv64)
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [310, 311, 312, 313, 313t, 314, 314t]
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: linux/riscv64
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v3.1.4
+        env:
+          CIBW_BUILD: "cp${{ matrix.python-version}}-*"
+          CIBW_ARCHS: riscv64
+          CIBW_SKIP: "*-musllinux*"
+          CIBW_BUILD_VERBOSITY: 3
+          CIBW_ENVIRONMENT_LINUX: PATH="$PATH:$HOME/.cargo/bin" CARGO_NET_GIT_FETCH_WITH_CLI=true
+          CIBW_ENABLE: cpython-freethreading
+
+      - uses: actions/upload-artifact@v6
+        with:
+          name: cibw-wheels-riscv64-${{ strategy.job-index }}
+          path: ./wheelhouse/*.whl
+
   build_sdist:
     name: sdist
     runs-on: ubuntu-latest
@@ -86,7 +118,7 @@ jobs:
   join_artifacts:
     name: Join artifacts
     runs-on: ubuntu-latest
-    needs: [build_wheels, build_wheels_aarch64, build_sdist]
+    needs: [build_wheels, build_wheels_aarch64, build_wheels_riscv64, build_sdist]
     steps:
      - name: Merge artifacts
        uses: actions/upload-artifact/merge@v4


### PR DESCRIPTION
## Summary

Add `linux_riscv64` wheels to the build workflow, mirroring the existing
aarch64 build job.

### Changes

- New `build_wheels_riscv64` job using cibuildwheel + QEMU emulation
- Targets CPython 3.10–3.14 (including free-threaded) on `manylinux_riscv64`
- Skips musllinux (no riscv64 image available)
- Includes Rust/Cargo environment for cross-compilation inside QEMU
- 120-minute timeout to account for QEMU + Rust compilation overhead
- Added to `join_artifacts` dependency list

### Evidence

A tested riscv64 wheel is available in our community index:
https://gounthar.github.io/riscv64-python-wheels/simple/tiktoken/

Built natively on BananaPi F3 (SpacemiT K1, rv64imafdcv, 8 cores @ 1.6 GHz, 16 GB RAM).

### Context

- `manylinux_2_28_riscv64` is available in pypa/manylinux
- cibuildwheel 3.x supports riscv64 via QEMU
- Rust cross-compiles to `riscv64gc-unknown-linux-gnu` inside the manylinux container
- Several packages already ship riscv64 wheels on PyPI (aiohttp, yarl, multidict, regex)
- RISC-V hardware is shipping (SiFive, SpacemiT K1/K3, Sophgo SG2044)

Closes #502

---

Note: this work is part of the [RISE Project](https://riseproject.dev/) effort to improve Python ecosystem support on riscv64 platforms. Native riscv64 CI runners are available for free via [RISE RISC-V runners](https://github.com/apps/rise-risc-v-runners).