### PR TITLE
Add PyInstaller hooks for tiktoken

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,9 @@ dependencies = ["regex", "requests"]
 optional-dependencies = { blobfile = ["blobfile>=3"] }
 requires-python = ">=3.9"
 
+[project.entry-points.pyinstaller40]
+hook-dirs = "tiktoken._pyinstaller:get_hook_dirs"
+
 [project.urls]
 homepage = "https://github.com/openai/tiktoken"
 repository = "https://github.com/openai/tiktoken"

--- a/tiktoken/_pyinstaller/__init__.py
+++ b/tiktoken/_pyinstaller/__init__.py
@@ -1,0 +1,5 @@
+import os
+
+
+def get_hook_dirs():
+    return [os.path.dirname(__file__)]

--- a/tiktoken/_pyinstaller/hook-tiktoken.py
+++ b/tiktoken/_pyinstaller/hook-tiktoken.py
@@ -1,0 +1,3 @@
+from PyInstaller.utils.hooks import collect_submodules
+
+hiddenimports = collect_submodules("tiktoken_ext")


### PR DESCRIPTION
Adds PyInstaller hooks so tiktoken works correctly when bundled via PyInstaller. Without these hooks, PyInstaller misses tiktoken's submodules and the bundled app fails at runtime with import errors. Registers the hook via the pyinstaller40 entry point following PyInstaller's hook packaging conventions.