### PR TITLE
Respect TIKTOKEN_OFFLINE env var to prevent network access in offline mode

### DIFF
--- a/tiktoken/load.py
+++ b/tiktoken/load.py
@@ -10,6 +10,13 @@ def read_file(blobpath: str) -> bytes:
         with open(blobpath, "rb", buffering=0) as f:
             return f.read()
 
+    if os.environ.get("TIKTOKEN_OFFLINE"):
+        raise ValueError(
+            f"TIKTOKEN_OFFLINE is set but {blobpath!r} is not present in the local cache. "
+            "Please ensure the file is cached before using offline mode, or unset "
+            "TIKTOKEN_OFFLINE to allow network access."
+        )
+
     if blobpath.startswith(("http://", "https://")):
         # avoiding blobfile for public files helps avoid auth issues, like MFA prompts.
         import requests
@@ -46,6 +53,12 @@ def read_file_cached(blobpath: str, expected_hash: str | None = None) -> bytes:
 
     if cache_dir == "":
         # disable caching
+        if os.environ.get("TIKTOKEN_OFFLINE"):
+            raise ValueError(
+                f"TIKTOKEN_OFFLINE is set and caching is disabled (TIKTOKEN_CACHE_DIR is empty), "
+                f"but {blobpath!r} requires a network fetch. Either remove TIKTOKEN_OFFLINE or "
+                "provide a valid TIKTOKEN_CACHE_DIR with the file already cached."
+            )
         return read_file(blobpath)
 
     cache_key = hashlib.sha1(blobpath.encode()).hexdigest()


### PR DESCRIPTION
## Problem

Fixes #513

In tiktoken 0.9.0+, the `TIKTOKEN_OFFLINE` environment variable is silently ignored. When the local cache is empty (e.g. fresh install in an air-gapped environment), `read_file()` proceeds to make HTTP requests even when `TIKTOKEN_OFFLINE=1` is set, causing unexpected network errors instead of a clear actionable message.

The `TIKTOKEN_CACHE_DIR` variable was also not helping in this scenario because even when set correctly, if the cache file was absent the code would fall through to a network fetch.

## Fix

- In `read_file()`: check `TIKTOKEN_OFFLINE` before attempting any network fetch (`http://`, `https://`, or blobfile). If set, raise a `ValueError` with a clear message explaining the situation.
- In `read_file_cached()`: guard the `TIKTOKEN_CACHE_DIR=""` (caching-disabled) path as well, raising early when `TIKTOKEN_OFFLINE` is set rather than delegating to `read_file()` after bypassing the cache lookup.

Local file paths (`"://" not in blobpath`) are unaffected and continue to work normally in offline mode.

## Behaviour after fix

| Scenario | Before | After |
|---|---|---|
| `TIKTOKEN_OFFLINE=1`, cache populated | Worked | Works (unchanged) |
| `TIKTOKEN_OFFLINE=1`, cache empty | Silent network error | Clear `ValueError` |
| `TIKTOKEN_OFFLINE=1`, `TIKTOKEN_CACHE_DIR=""` | Silent network error | Clear `ValueError` |
| No `TIKTOKEN_OFFLINE`, any path | Worked | Works (unchanged) |

## Test plan

- [ ] Verify that setting `TIKTOKEN_OFFLINE=1` with a pre-populated cache still loads the tokenizer successfully
- [ ] Verify that setting `TIKTOKEN_OFFLINE=1` with an empty cache raises `ValueError` with a clear message (no network attempt)
- [ ] Verify that existing tests continue to pass