### PR TITLE
Honor offline cache for encoding downloads

### DIFF
--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -1,0 +1,40 @@
+import hashlib
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_LOAD_SPEC = importlib.util.spec_from_file_location(
+    "tiktoken_load_for_tests",
+    Path(__file__).resolve().parents[1] / "tiktoken" / "load.py",
+)
+assert _LOAD_SPEC is not None and _LOAD_SPEC.loader is not None
+_LOAD_MODULE = importlib.util.module_from_spec(_LOAD_SPEC)
+_LOAD_SPEC.loader.exec_module(_LOAD_MODULE)
+read_file_cached = _LOAD_MODULE.read_file_cached
+
+
+def test_read_file_cached_offline_uses_legacy_filename_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    blobpath = "https://openaipublic.blob.core.windows.net/encodings/cl100k_base.tiktoken"
+    contents = b"hello from cache"
+    expected_hash = hashlib.sha256(contents).hexdigest()
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    (cache_dir / "cl100k_base.tiktoken").write_bytes(contents)
+
+    monkeypatch.setenv("TIKTOKEN_CACHE_DIR", str(cache_dir))
+    monkeypatch.setenv("TIKTOKEN_OFFLINE", "1")
+
+    assert read_file_cached(blobpath, expected_hash) == contents
+
+
+def test_read_file_cached_offline_cache_miss_does_not_hit_network(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    blobpath = "https://openaipublic.blob.core.windows.net/encodings/cl100k_base.tiktoken"
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+
+    monkeypatch.setenv("TIKTOKEN_CACHE_DIR", str(cache_dir))
+    monkeypatch.setenv("TIKTOKEN_OFFLINE", "1")
+
+    with pytest.raises(FileNotFoundError, match="offline mode enabled"):
+        read_file_cached(blobpath)

--- a/tiktoken/load.py
+++ b/tiktoken/load.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import base64
 import hashlib
 import os
+from urllib.parse import urlparse
 
 
 def read_file(blobpath: str) -> bytes:
@@ -32,6 +33,17 @@ def check_hash(data: bytes, expected_hash: str) -> bool:
     return actual_hash == expected_hash
 
 
+def _legacy_cache_path(cache_dir: str, blobpath: str) -> str | None:
+    if "://" not in blobpath:
+        return os.path.join(cache_dir, os.path.basename(blobpath))
+
+    parsed = urlparse(blobpath)
+    filename = os.path.basename(parsed.path)
+    if not filename:
+        return None
+    return os.path.join(cache_dir, filename)
+
+
 def read_file_cached(blobpath: str, expected_hash: str | None = None) -> bytes:
     user_specified_cache = True
     if "TIKTOKEN_CACHE_DIR" in os.environ:
@@ -50,8 +62,15 @@ def read_file_cached(blobpath: str, expected_hash: str | None = None) -> bytes:
 
     cache_key = hashlib.sha1(blobpath.encode()).hexdigest()
 
-    cache_path = os.path.join(cache_dir, cache_key)
-    if os.path.exists(cache_path):
+    cache_paths = [os.path.join(cache_dir, cache_key)]
+    legacy_cache_path = _legacy_cache_path(cache_dir, blobpath)
+    if legacy_cache_path and legacy_cache_path not in cache_paths:
+        cache_paths.append(legacy_cache_path)
+
+    for cache_path in cache_paths:
+        if not os.path.exists(cache_path):
+            continue
+
         with open(cache_path, "rb", buffering=0) as f:
             data = f.read()
         if expected_hash is None or check_hash(data, expected_hash):
@@ -62,6 +81,9 @@ def read_file_cached(blobpath: str, expected_hash: str | None = None) -> bytes:
             os.remove(cache_path)
         except OSError:
             pass
+
+    if os.environ.get("TIKTOKEN_OFFLINE") not in (None, "", "0"):
+        raise FileNotFoundError(f"offline mode enabled and cache miss for {blobpath}")
 
     contents = read_file(blobpath)
     if expected_hash and not check_hash(contents, expected_hash):


### PR DESCRIPTION
## Summary
- honor TIKTOKEN_OFFLINE before any network fetch is attempted
- check legacy filename-based cache entries in user-specified cache directories as a fallback
- add regression coverage for offline cache hits and offline cache misses

## Testing
- python3 -m pytest tests/test_load.py

Closes #513