### PR TITLE
build: add PyInstaller hooks for dynamic encodings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,9 @@ homepage = "https://github.com/openai/tiktoken"
 repository = "https://github.com/openai/tiktoken"
 changelog = "https://github.com/openai/tiktoken/blob/main/CHANGELOG.md"
 
+[project.entry-points.pyinstaller40]
+hook-dirs = "tiktoken._pyinstaller:get_hook_dirs"
+
 [build-system]
 build-backend = "setuptools.build_meta"
 requires = ["setuptools>=62.4", "wheel", "setuptools-rust>=1.5.2"]

--- a/tiktoken/_pyinstaller/__init__.py
+++ b/tiktoken/_pyinstaller/__init__.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def get_hook_dirs() -> list[str]:
+    return [str(Path(__file__).resolve().parent)]

--- a/tiktoken/_pyinstaller/hook-tiktoken.py
+++ b/tiktoken/_pyinstaller/hook-tiktoken.py
@@ -1,0 +1,4 @@
+from PyInstaller.utils.hooks import collect_submodules
+
+
+hiddenimports = collect_submodules("tiktoken_ext")


### PR DESCRIPTION
## Summary
- register a pyinstaller40 hook directory for tiktoken
- add a hook that collects tiktoken_ext submodules so bundled apps can discover encoding plugins at runtime

## Testing
- not run (packaging-only change)

Closes #469