### PR TITLE
ci: use static artifact name for sdist build job

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -80,7 +80,7 @@ jobs:
           python -m build --sdist
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
-          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
+          name: cibw-wheels-sdist
           path: ./dist/*.tar.gz
 
   join_artifacts:


### PR DESCRIPTION
Closes #534

The `build_sdist` job in `.github/workflows/build_wheels.yml` uploads its artifact with `name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}`, but that job has no matrix, so both expressions expand to empty strings and the artifact is named `cibw-wheels--` at runtime.

Fix: use a static `cibw-wheels-sdist` for the sdist job. The `join_artifacts` merge step still picks it up because its pattern is `cibw-wheels-*`.