### PR TITLE
fix: resolve AttributeError in Encoding.is_special_token()

### DIFF
--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -223,6 +223,17 @@ def test_special_token():
     assert fim in tokens
 
 
+def test_is_special_token():
+    enc = tiktoken.get_encoding("cl100k_base")
+
+    eot = enc.encode_single_token("<|endoftext|>")
+    assert enc.is_special_token(eot)
+
+    # a regular token should not be special
+    hello_tokens = enc.encode("hello")
+    assert not enc.is_special_token(hello_tokens[0])
+
+
 @pytest.mark.parametrize("make_enc", ENCODING_FACTORIES)
 @hypothesis.given(text=st.text())
 @hypothesis.settings(deadline=None, max_examples=MAX_EXAMPLES)

--- a/tiktoken/core.py
+++ b/tiktoken/core.py
@@ -364,7 +364,7 @@ class Encoding:
 
     def is_special_token(self, token: int) -> bool:
         assert isinstance(token, int)
-        return token in self._special_token_values
+        return token in self._special_tokens.values()
 
     @property
     def n_vocab(self) -> int:


### PR DESCRIPTION
Fixes #536.

`is_special_token()` references `self._special_token_values` which is never defined anywhere in the class, causing `AttributeError` on every call. Changed to `self._special_tokens.values()` which correctly checks if the token id is among the special token values. Added a test covering both special and regular tokens.