### PR TITLE
Fix AttributeError in is_special_token() — use _special_tokens.values() instead of undefined _special_token_values

### DIFF
--- a/tiktoken/core.py
+++ b/tiktoken/core.py
@@ -364,7 +364,7 @@ class Encoding:
 
     def is_special_token(self, token: int) -> bool:
         assert isinstance(token, int)
-        return token in self._special_token_values
+        return token in self._special_tokens.values()
 
     @property
     def n_vocab(self) -> int:


### PR DESCRIPTION
Fixes #536

The `is_special_token()` method in `tiktoken/core.py` (line 367) references `self._special_token_values`, but that attribute is never defined anywhere in the `Encoding` class. The `__init__` method only sets `self._special_tokens`, which is a `dict[str, int]` mapping special token strings to their integer values.

As a result, any call to `is_special_token()` raises an `AttributeError`:

```python
import tiktoken

enc = tiktoken.get_encoding("cl100k_base")
eot = enc.encode_single_token("<|endoftext|>")
enc.is_special_token(eot)
# AttributeError: 'Encoding' object has no attribute '_special_token_values'
```

The fix is straightforward: change `self._special_token_values` to `self._special_tokens.values()`, which gives us the collection of integer token IDs from the existing dict. This matches the pattern already used nearby in `special_tokens_set()`, which calls `self._special_tokens.keys()`.