### PR TITLE
Handle surrogate pairs in unstable encoding

### DIFF
--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -110,6 +110,24 @@ def test_encode_surrogate_pairs():
     assert enc.encode("\ud83d") == enc.encode("�")
 
 
+def test_encode_surrogate_pairs_unstable():
+    enc = tiktoken.get_encoding("cl100k_base")
+
+    surrogate_pair_stable, surrogate_pair_completions = enc.encode_with_unstable("\ud83d\udc4d")
+    codepoint_stable, codepoint_completions = enc.encode_with_unstable("👍")
+    assert surrogate_pair_stable == codepoint_stable
+    assert {tuple(seq) for seq in surrogate_pair_completions} == {
+        tuple(seq) for seq in codepoint_completions
+    }
+
+    lone_surrogate_stable, lone_surrogate_completions = enc.encode_with_unstable("\ud83d")
+    replacement_stable, replacement_completions = enc.encode_with_unstable("�")
+    assert lone_surrogate_stable == replacement_stable
+    assert {tuple(seq) for seq in lone_surrogate_completions} == {
+        tuple(seq) for seq in replacement_completions
+    }
+
+
 @pytest.mark.parametrize("make_enc", ENCODING_FACTORIES)
 def test_catastrophically_repetitive(make_enc: Callable[[], tiktoken.Encoding]):
     enc = make_enc()

--- a/tiktoken/core.py
+++ b/tiktoken/core.py
@@ -237,7 +237,12 @@ class Encoding:
             if match := _special_token_regex(disallowed_special).search(text):
                 raise_disallowed_special_token(match.group())
 
-        return self._core_bpe.encode_with_unstable(text, allowed_special)
+        try:
+            return self._core_bpe.encode_with_unstable(text, allowed_special)
+        except UnicodeEncodeError:
+            # Repair surrogate pairs and replace lone surrogates before crossing into Rust.
+            text = text.encode("utf-16", "surrogatepass").decode("utf-16", "replace")
+            return self._core_bpe.encode_with_unstable(text, allowed_special)
 
     def encode_single_token(self, text_or_bytes: str | bytes) -> int:
         """Encodes text corresponding to a single token to its token value.


### PR DESCRIPTION
Fixes #541 

`encode` and `encode_ordinary` already retry with UTF-16 surrogate repair when the Rust core raises `UnicodeEncodeError`.

This applies the same behavior to `encode_with_unstable`, so surrogate pairs and lone surrogates are handled consistently across Python encoding APIs.

Added a regression test for `encode_with_unstable`.

Tested with:

```text
python -m pytest tests/test_encoding.py -q
