### PR TITLE
fix(py): report element count in `buffer.shape`, not byte length (#405)

### DIFF
--- a/src/py.rs
+++ b/src/py.rs
@@ -65,7 +65,7 @@ impl CoreBPE {
             Err(e) => return Err(PyErr::new::<exceptions::PyValueError, _>(e.message)),
         };
 
-        let buffer = TiktokenBuffer { tokens };
+        let buffer = TiktokenBuffer::new(tokens);
         buffer.into_py_any(py)
     }
 
@@ -186,6 +186,17 @@ impl CoreBPE {
 #[pyclass(frozen)]
 struct TiktokenBuffer {
     tokens: Vec<Rank>,
+    // Per the buffer protocol, `view.shape[0]` must be the element count
+    // (so that `prod(shape) * itemsize == len`). Box it so the pointer we
+    // hand out in `__getbuffer__` is stable for the lifetime of `self`.
+    shape: Box<pyo3::ffi::Py_ssize_t>,
+}
+
+impl TiktokenBuffer {
+    fn new(tokens: Vec<Rank>) -> Self {
+        let shape = Box::new(tokens.len() as pyo3::ffi::Py_ssize_t);
+        Self { tokens, shape }
+    }
 }
 
 #[pymethods]
@@ -208,7 +219,8 @@ impl TiktokenBuffer {
             let view_ref = &mut *view;
             view_ref.obj = slf.clone().into_any().into_ptr();
 
-            let data = &slf.borrow().tokens;
+            let borrowed = slf.borrow();
+            let data = &borrowed.tokens;
             view_ref.buf = data.as_ptr() as *mut std::os::raw::c_void;
             view_ref.len = (data.len() * std::mem::size_of::<Rank>()) as isize;
             view_ref.readonly = 1;
@@ -221,7 +233,10 @@ impl TiktokenBuffer {
             };
             view_ref.ndim = 1;
             view_ref.shape = if (flags & pyo3::ffi::PyBUF_ND) == pyo3::ffi::PyBUF_ND {
-                &mut view_ref.len
+                // Element count, not byte length, per PEP 3118.
+                // The Box lives as long as `self` (kept alive via `view_ref.obj`),
+                // so this pointer is valid for the buffer view's lifetime.
+                &*borrowed.shape as *const pyo3::ffi::Py_ssize_t as *mut pyo3::ffi::Py_ssize_t
             } else {
                 std::ptr::null_mut()
             };

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -28,3 +28,19 @@ import sys
 assert "blobfile" not in sys.modules
 """
     subprocess.check_call([sys.executable, "-c", prog])
+
+
+def test_tiktoken_buffer_shape_is_element_count():
+    # Regression test for the buffer protocol's `shape` reporting bytes
+    # instead of element count, which caused `memoryview(...).tolist()`
+    # to expand each token into 4 byte-sized integers. See issue #405.
+    import math
+
+    enc = tiktoken.get_encoding("gpt2")
+    expected = enc.encode("hello world")
+    buf = enc._core_bpe.encode_to_tiktoken_buffer("hello world", frozenset())
+
+    mv = memoryview(buf)
+    # Per PEP 3118: prod(shape) * itemsize == nbytes
+    assert math.prod(mv.shape) * mv.itemsize == mv.nbytes
+    assert mv.tolist() == expected


### PR DESCRIPTION
## Summary

Fixes #405.

`TiktokenBuffer.__getbuffer__` pointed `view.shape` at the same `Py_ssize_t` storage as `view.len`, so the shape it reported was the **byte length** rather than the **element count**. PEP 3118 requires `prod(shape) * itemsize == nbytes`, and any consumer that respects `shape` (most prominently CPython's own `memoryview(...).tolist()`) reads the wrong count.

NumPy is unaffected because `np.frombuffer` derives the count from `len / itemsize` directly — which is how this slipped through `Encoding.encode_to_numpy`.

### Before

```python
>>> import tiktoken
>>> enc = tiktoken.get_encoding("gpt2")
>>> buf = enc._core_bpe.encode_to_tiktoken_buffer("hello world", frozenset())
>>> mv = memoryview(buf)
>>> mv.shape          # bytes, not tokens
(8,)
>>> mv.tolist()       # expands each token to 4 byte-sized ints
[31373, 0, 0, 0, 995, 0, 0, 0]
```

### After

```python
>>> mv.shape
(2,)
>>> mv.tolist()
[31373, 995]
```

## Implementation

The shape value needs storage that outlives the function call (the buffer view's lifetime is tied to the Python object via `view.obj`, not the function frame). I added a `Box<Py_ssize_t>` field to `TiktokenBuffer` holding the element count, and point `view.shape` at it. The box lives as long as `self`, so the pointer is valid for the buffer view's lifetime.

## Tests

Added a regression test `test_tiktoken_buffer_shape_is_element_count` in `tests/test_misc.py`:

```python
def test_tiktoken_buffer_shape_is_element_count():
    enc = tiktoken.get_encoding("gpt2")
    expected = enc.encode("hello world")
    buf = enc._core_bpe.encode_to_tiktoken_buffer("hello world", frozenset())
    mv = memoryview(buf)
    assert math.prod(mv.shape) * mv.itemsize == mv.nbytes  # PEP 3118 invariant
    assert mv.tolist() == expected
```

## Verification

`cargo check --all-features` clean (only pre-existing unrelated pyo3 deprecation warning).
`pytest tests/test_misc.py::test_tiktoken_buffer_shape_is_element_count -v` passes after the fix; the same test fails on `main` before the fix (`prod((8,)) * 4 == 8` → `32 != 8`).