### PR TITLE
build: enable line tables in release builds so backtraces show file:line (#103)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,9 @@ fancy-regex = "0.17.0"
 regex = "1.10.3"
 rustc-hash = "2"
 bstr = "1.5.0"
+
+[profile.release]
+# Keep line tables in release builds so panic stack traces include
+# file/line numbers without significantly inflating wheel size or
+# affecting runtime performance.
+debug = "line-tables-only"


### PR DESCRIPTION
## Summary

Fixes #103.

Release builds of the tiktoken Rust extension strip all debug info, so panic stack traces surface in Python without any file or line numbers. Adding `debug = "line-tables-only"` to the release profile keeps just enough DWARF to resolve backtraces to file:line, without the binary-size cost of full `debug = true`.

```toml
[profile.release]
debug = "line-tables-only"
```

## Why `line-tables-only` and not `debug = true`?

The reporter's original suggestion was `debug = true`, and their benchmark in the issue showed no runtime impact. Both options give you the line numbers. `line-tables-only` (stable since Rust 1.69) is a strict subset that drops variable / type information while keeping `.debug_line`, so:

- Backtraces still resolve `function_name (path/file.rs:42)` ✅
- Wheel size grows much less than with `debug = true`
- No runtime perf change (optimization level is unaffected — the only thing that changes is the size of `.debug_*` sections, which aren't loaded into memory at runtime)

Happy to switch to `debug = true` if maintainers prefer it for parity with the original issue.

## MSRV check

`line-tables-only` was stabilized in Rust 1.69 (May 2023). `Cargo.toml` already declares `edition = "2024"`, which requires Rust 1.85+, so this is well within the existing MSRV.

## Verification

- `cargo check --release --all-features` passes (only pre-existing pyo3 deprecation warning).