### PR TITLE
Close unterminated code fence in encode_ordinary docstring

### DIFF
--- a/tiktoken/core.py
+++ b/tiktoken/core.py
@@ -71,6 +71,7 @@ class Encoding:
         ```
         >>> enc.encode_ordinary("hello world")
         [31373, 995]
+        ```
         """
         try:
             return self._core_bpe.encode_ordinary(text)


### PR DESCRIPTION
The Markdown code block opened with triple backticks in the encode_ordinary docstring is never closed, so the example bleeds into the rest of the docstring when rendered by tools that respect Markdown fencing (and shows visibly in help output). All sibling methods on Encoding terminate their fences with a matching triple backtick; this brings encode_ordinary in line.

Before:

    >>> help(tiktoken.Encoding.encode_ordinary)
    ...
        ```
        >>> enc.encode_ordinary("hello world")
        [31373, 995]

After:

    >>> help(tiktoken.Encoding.encode_ordinary)
    ...
        ```
        >>> enc.encode_ordinary("hello world")
        [31373, 995]
        ```

No behaviour change.