### PR TITLE
Add 2-byte pair lookup table to skip hashmap for initial BPE merge scan

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,9 @@ mod py;
 
 pub type Rank = u32;
 
+// Every distinct 2-byte sequence (256 byte values × 256). Indexed by (byte_a << 8) | byte_b.
+const PAIR_TABLE_SIZE: usize = 256 * 256;
+
 use std::collections::BinaryHeap;
 
 #[derive(Eq, PartialEq, Clone, Copy)]
@@ -47,7 +50,7 @@ struct State {
 fn _byte_pair_merge_large(
     ranks: &HashMap<Vec<u8>, Rank>,
     piece: &[u8],
-    pair_table: Option<&[Rank; 65536]>,
+    pair_table: Option<&[Rank; PAIR_TABLE_SIZE]>,
 ) -> Vec<Rank> {
     let mut state = Vec::with_capacity(piece.len());
     state.push(State {
@@ -153,7 +156,7 @@ fn _byte_pair_merge_large(
 fn _byte_pair_merge(
     ranks: &HashMap<Vec<u8>, Rank>,
     piece: &[u8],
-    pair_table: Option<&[Rank; 65536]>,
+    pair_table: Option<&[Rank; PAIR_TABLE_SIZE]>,
 ) -> Vec<(usize, Rank)> {
     // This is a vector of (start, rank).
     // The rank is of the pair starting at position start.
@@ -163,9 +166,9 @@ fn _byte_pair_merge(
     // the way we currently do, this is equivalent. An easy way to break this would be to decouple
     // merge priority from token index or to prevent specific token merges.
     //
-    // When `pair_table` is Some, the initial pair scan uses a flat 65k-entry array indexed by
-    // the 2-byte pair instead of the hashmap. Subsequent merges (3+ byte sequences) always go
-    // through the hashmap, since 3+ byte keys don't fit in a u16.
+    // When `pair_table` is Some, the initial pair scan uses a flat `PAIR_TABLE_SIZE`-entry
+    // array indexed by the 2-byte pair instead of the hashmap. Subsequent merges (3+ byte
+    // sequences) always go through the hashmap, since 3+ byte keys don't fit in a u16.
     let mut min_rank: (Rank, usize) = (Rank::MAX, usize::MAX);
     for i in 0..piece.len() - 1 {
         let rank = match pair_table {
@@ -240,7 +243,7 @@ pub fn byte_pair_encode(piece: &[u8], ranks: &HashMap<Vec<u8>, Rank>) -> Vec<Ran
 fn byte_pair_encode_with_table(
     piece: &[u8],
     ranks: &HashMap<Vec<u8>, Rank>,
-    pair_table: &[Rank; 65536],
+    pair_table: &[Rank; PAIR_TABLE_SIZE],
 ) -> Vec<Rank> {
     let piece_len = piece.len();
 
@@ -374,7 +377,7 @@ pub struct CoreBPE {
     /// Precomputed 2-byte pair to rank lookup table (~256 KB, built once at
     /// construction). Used by encoding methods to skip the hashmap lookup for
     /// the hot initial adjacent-pair scan inside `_byte_pair_merge`.
-    pair_table: Box<[Rank; 65536]>,
+    pair_table: Box<[Rank; PAIR_TABLE_SIZE]>,
 }
 
 impl CoreBPE {
@@ -606,11 +609,10 @@ impl CoreBPE {
                     // notice all the big holes in the previous unstable token implementation)
                     Err(_) => {
                         byte_pair_encode_with_table(&possibility, &self.encoder, &self.pair_table)
-                    }
-                    // Something like the following is intriguing but incorrect:
-                    // Err(e) => self.encode_ordinary(unsafe {
-                    //     std::str::from_utf8_unchecked(&possibility[..e.valid_up_to()])
-                    // }),
+                    } // Something like the following is intriguing but incorrect:
+                      // Err(e) => self.encode_ordinary(unsafe {
+                      //     std::str::from_utf8_unchecked(&possibility[..e.valid_up_to()])
+                      // }),
                 };
                 let mut seq = Vec::new();
                 let mut seq_len = 0;
@@ -708,7 +710,7 @@ impl CoreBPE {
         sorted_token_bytes.sort();
 
         // Build the 2-byte pair lookup table (~256 KB, sub-millisecond one-time cost).
-        let mut pair_table: Box<[Rank; 65536]> = Box::new([Rank::MAX; 65536]);
+        let mut pair_table: Box<[Rank; PAIR_TABLE_SIZE]> = Box::new([Rank::MAX; PAIR_TABLE_SIZE]);
         for (key, &rank) in &encoder {
             if key.len() == 2 {
                 let idx = ((key[0] as u16) << 8 | key[1] as u16) as usize;
@@ -766,5 +768,116 @@ mod tests {
         let ranks = setup_ranks();
         let res = byte_pair_split(b"abab", &ranks);
         assert_eq!(res, vec![b"ab", b"ab"]);
+    }
+}
+
+/// Tests that the precomputed 2-byte pair lookup table produces output
+/// byte-identical to the vanilla hashmap-lookup path. Covers both the
+/// linear `_byte_pair_merge` (pieces < 100 bytes) and the heap-based
+/// `_byte_pair_merge_large` (pieces >= 100 bytes) code paths.
+#[cfg(test)]
+mod pair_table_equivalence {
+    use super::*;
+
+    /// Build a small synthetic encoder: all ASCII a-z and 0-9 as single-byte
+    /// tokens, plus a handful of common 2-byte and 3-byte merges. Enough to
+    /// exercise real merge dynamics without depending on a downloaded vocab.
+    fn synthetic_encoder() -> HashMap<Vec<u8>, Rank> {
+        let mut encoder = HashMap::default();
+        let mut rank: Rank = 0;
+        for b in b'a'..=b'z' {
+            encoder.insert(vec![b], rank);
+            rank += 1;
+        }
+        for b in b'0'..=b'9' {
+            encoder.insert(vec![b], rank);
+            rank += 1;
+        }
+        for pair in ["th", "he", "in", "er", "an", "re", "on", "at", "es", "or"] {
+            encoder.insert(pair.as_bytes().to_vec(), rank);
+            rank += 1;
+        }
+        for triple in ["the", "and", "ing", "ion", "for"] {
+            encoder.insert(triple.as_bytes().to_vec(), rank);
+            rank += 1;
+        }
+        encoder
+    }
+
+    fn build_pair_table(encoder: &HashMap<Vec<u8>, Rank>) -> Box<[Rank; PAIR_TABLE_SIZE]> {
+        let mut pair_table: Box<[Rank; PAIR_TABLE_SIZE]> = Box::new([Rank::MAX; PAIR_TABLE_SIZE]);
+        for (key, &rank) in encoder {
+            if key.len() == 2 {
+                let idx = ((key[0] as u16) << 8 | key[1] as u16) as usize;
+                pair_table[idx] = rank;
+            }
+        }
+        pair_table
+    }
+
+    fn check_equivalence(piece: &[u8]) {
+        let encoder = synthetic_encoder();
+        let pair_table = build_pair_table(&encoder);
+        let vanilla = byte_pair_encode(piece, &encoder);
+        let patched = byte_pair_encode_with_table(piece, &encoder, &pair_table);
+        assert_eq!(
+            vanilla,
+            patched,
+            "vanilla vs pair-table diverged on piece of length {}",
+            piece.len(),
+        );
+    }
+
+    /// Generate an alphabetic piece of the requested length by cycling a..z.
+    fn alpha_piece(n: usize) -> Vec<u8> {
+        (0..n).map(|i| b'a' + ((i % 26) as u8)).collect()
+    }
+
+    #[test]
+    fn equivalence_length_1_direct_lookup() {
+        // Single byte takes the early-return path; pair table never consulted.
+        check_equivalence(b"a");
+        check_equivalence(b"z");
+        check_equivalence(b"0");
+    }
+
+    #[test]
+    fn equivalence_short_pieces_linear_path() {
+        // Pieces < 100 bytes go through `_byte_pair_merge` (linear scan).
+        check_equivalence(b"th");
+        check_equivalence(b"the");
+        check_equivalence(b"that");
+        check_equivalence(b"information");
+        check_equivalence(b"theandingionfor");
+    }
+
+    #[test]
+    fn equivalence_just_under_100b_cutoff() {
+        check_equivalence(&alpha_piece(50));
+        check_equivalence(&alpha_piece(98));
+        check_equivalence(&alpha_piece(99));
+    }
+
+    #[test]
+    fn equivalence_at_100b_cutoff() {
+        // 100 bytes is the boundary: dispatches to `_byte_pair_merge_large`.
+        check_equivalence(&alpha_piece(100));
+        check_equivalence(&alpha_piece(101));
+    }
+
+    #[test]
+    fn equivalence_long_pieces_heap_path() {
+        // Well into the heap-based path.
+        check_equivalence(&alpha_piece(200));
+        check_equivalence(&alpha_piece(500));
+        check_equivalence(&alpha_piece(1000));
+    }
+
+    #[test]
+    fn equivalence_repeated_pairs() {
+        // Many identical 2-byte pairs to stress the initial-scan path.
+        check_equivalence(&[b'x'; 5]);
+        check_equivalence(&[b'x'; 99]);
+        check_equivalence(&[b'x'; 150]);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,11 @@ struct State {
     cur_rank: Rank,
 }
 
-fn _byte_pair_merge_large(ranks: &HashMap<Vec<u8>, Rank>, piece: &[u8]) -> Vec<Rank> {
+fn _byte_pair_merge_large(
+    ranks: &HashMap<Vec<u8>, Rank>,
+    piece: &[u8],
+    pair_table: Option<&[Rank; 65536]>,
+) -> Vec<Rank> {
     let mut state = Vec::with_capacity(piece.len());
     state.push(State {
         prev: usize::MAX,
@@ -56,7 +60,16 @@ fn _byte_pair_merge_large(ranks: &HashMap<Vec<u8>, Rank>, piece: &[u8]) -> Vec<R
 
     let mut heap = BinaryHeap::with_capacity(piece.len());
     for i in 0..piece.len() - 1 {
-        if let Some(&rank) = ranks.get(&piece[i..i + 2]) {
+        // When `pair_table` is Some, look up the 2-byte pair rank via flat array index instead
+        // of the hashmap. Same semantics: `Rank::MAX` in the table means "not in vocab" so skip.
+        let rank_opt = match pair_table {
+            Some(table) => {
+                let r = table[((piece[i] as u16) << 8 | piece[i + 1] as u16) as usize];
+                (r != Rank::MAX).then_some(r)
+            }
+            None => ranks.get(&piece[i..i + 2]).copied(),
+        };
+        if let Some(rank) = rank_opt {
             heap.push(Merge { start: i, rank });
             state[i].next_rank = rank;
         }
@@ -137,7 +150,11 @@ fn _byte_pair_merge_large(ranks: &HashMap<Vec<u8>, Rank>, piece: &[u8]) -> Vec<R
     result
 }
 
-fn _byte_pair_merge(ranks: &HashMap<Vec<u8>, Rank>, piece: &[u8]) -> Vec<(usize, Rank)> {
+fn _byte_pair_merge(
+    ranks: &HashMap<Vec<u8>, Rank>,
+    piece: &[u8],
+    pair_table: Option<&[Rank; 65536]>,
+) -> Vec<(usize, Rank)> {
     // This is a vector of (start, rank).
     // The rank is of the pair starting at position start.
     let mut parts = Vec::with_capacity(piece.len() + 1);
@@ -145,9 +162,16 @@ fn _byte_pair_merge(ranks: &HashMap<Vec<u8>, Rank>, piece: &[u8]) -> Vec<(usize,
     // Note that we hash bytes when indexing into `ranks`, not token pairs. As long as we train BPE
     // the way we currently do, this is equivalent. An easy way to break this would be to decouple
     // merge priority from token index or to prevent specific token merges.
+    //
+    // When `pair_table` is Some, the initial pair scan uses a flat 65k-entry array indexed by
+    // the 2-byte pair instead of the hashmap. Subsequent merges (3+ byte sequences) always go
+    // through the hashmap, since 3+ byte keys don't fit in a u16.
     let mut min_rank: (Rank, usize) = (Rank::MAX, usize::MAX);
     for i in 0..piece.len() - 1 {
-        let rank = *ranks.get(&piece[i..i + 2]).unwrap_or(&Rank::MAX);
+        let rank = match pair_table {
+            Some(table) => table[((piece[i] as u16) << 8 | piece[i + 1] as u16) as usize],
+            None => *ranks.get(&piece[i..i + 2]).unwrap_or(&Rank::MAX),
+        };
         if rank < min_rank.0 {
             min_rank = (rank, i);
         }
@@ -202,17 +226,39 @@ pub fn byte_pair_encode(piece: &[u8], ranks: &HashMap<Vec<u8>, Rank>) -> Vec<Ran
         return vec![ranks[piece]];
     }
     if piece_len < 100 {
-        return _byte_pair_merge(ranks, piece)
+        return _byte_pair_merge(ranks, piece, None)
             .windows(2)
             .map(|part| ranks[&piece[part[0].0..part[1].0]])
             .collect();
     }
-    _byte_pair_merge_large(ranks, piece)
+    _byte_pair_merge_large(ranks, piece, None)
+}
+
+/// Like [`byte_pair_encode`] but uses a precomputed 2-byte pair lookup table
+/// for the initial pair scan. Used internally by `CoreBPE` methods to skip the
+/// hashmap lookup for the hot initial scan.
+fn byte_pair_encode_with_table(
+    piece: &[u8],
+    ranks: &HashMap<Vec<u8>, Rank>,
+    pair_table: &[Rank; 65536],
+) -> Vec<Rank> {
+    let piece_len = piece.len();
+
+    if piece_len == 1 {
+        return vec![ranks[piece]];
+    }
+    if piece_len < 100 {
+        return _byte_pair_merge(ranks, piece, Some(pair_table))
+            .windows(2)
+            .map(|part| ranks[&piece[part[0].0..part[1].0]])
+            .collect();
+    }
+    _byte_pair_merge_large(ranks, piece, Some(pair_table))
 }
 
 pub fn byte_pair_split<'a>(piece: &'a [u8], ranks: &HashMap<Vec<u8>, Rank>) -> Vec<&'a [u8]> {
     assert!(piece.len() > 1);
-    _byte_pair_merge(ranks, piece)
+    _byte_pair_merge(ranks, piece, None)
         .windows(2)
         .map(|part| &piece[part[0].0..part[1].0])
         .collect()
@@ -325,6 +371,10 @@ pub struct CoreBPE {
     regex_tls: Vec<Regex>,
     special_regex_tls: Vec<Regex>,
     sorted_token_bytes: Vec<Vec<u8>>,
+    /// Precomputed 2-byte pair to rank lookup table (~256 KB, built once at
+    /// construction). Used by encoding methods to skip the hashmap lookup for
+    /// the hot initial adjacent-pair scan inside `_byte_pair_merge`.
+    pair_table: Box<[Rank; 65536]>,
 }
 
 impl CoreBPE {
@@ -366,7 +416,11 @@ impl CoreBPE {
             let piece = mat.unwrap().as_str().as_bytes();
             match self.encoder.get(piece) {
                 Some(token) => ret.push(*token),
-                None => ret.extend(&byte_pair_encode(piece, &self.encoder)),
+                None => ret.extend(&byte_pair_encode_with_table(
+                    piece,
+                    &self.encoder,
+                    &self.pair_table,
+                )),
             }
         }
         ret
@@ -418,7 +472,7 @@ impl CoreBPE {
                     ret.push(*token);
                     continue;
                 }
-                let tokens = byte_pair_encode(piece, &self.encoder);
+                let tokens = byte_pair_encode_with_table(piece, &self.encoder, &self.pair_table);
                 last_piece_token_len = tokens.len();
                 ret.extend(&tokens);
             }
@@ -550,7 +604,9 @@ impl CoreBPE {
                     // would be a regex split before the UTF-8 truncation point.
                     // Probably niche enough that no one will ever notice (after all, people didn't
                     // notice all the big holes in the previous unstable token implementation)
-                    Err(_) => byte_pair_encode(&possibility, &self.encoder),
+                    Err(_) => {
+                        byte_pair_encode_with_table(&possibility, &self.encoder, &self.pair_table)
+                    }
                     // Something like the following is intriguing but incorrect:
                     // Err(e) => self.encode_ordinary(unsafe {
                     //     std::str::from_utf8_unchecked(&possibility[..e.valid_up_to()])
@@ -583,13 +639,15 @@ impl CoreBPE {
             if unstable_bytes.len() - last_decoded.1 > 0
                 && last_decoded.0.is_some_and(|c| c.is_whitespace())
             {
-                let mut reencoded = byte_pair_encode(
+                let mut reencoded = byte_pair_encode_with_table(
                     &unstable_bytes[..unstable_bytes.len() - last_decoded.1],
                     &self.encoder,
+                    &self.pair_table,
                 );
-                reencoded.extend(byte_pair_encode(
+                reencoded.extend(byte_pair_encode_with_table(
                     &unstable_bytes[unstable_bytes.len() - last_decoded.1..],
                     &self.encoder,
+                    &self.pair_table,
                 ));
                 completions.insert(reencoded);
             }
@@ -649,6 +707,15 @@ impl CoreBPE {
         let mut sorted_token_bytes: Vec<Vec<u8>> = encoder.keys().cloned().collect();
         sorted_token_bytes.sort();
 
+        // Build the 2-byte pair lookup table (~256 KB, sub-millisecond one-time cost).
+        let mut pair_table: Box<[Rank; 65536]> = Box::new([Rank::MAX; 65536]);
+        for (key, &rank) in &encoder {
+            if key.len() == 2 {
+                let idx = ((key[0] as u16) << 8 | key[1] as u16) as usize;
+                pair_table[idx] = rank;
+            }
+        }
+
         Ok(Self {
             encoder,
             special_tokens_encoder,
@@ -659,6 +726,7 @@ impl CoreBPE {
                 .map(|_| special_regex.clone())
                 .collect(),
             sorted_token_bytes,
+            pair_table,
         })
     }
 


### PR DESCRIPTION
## Summary

Adds a precomputed 2-byte pair to rank table (`Box<[Rank; 65536]>`, ~256 KB) on `CoreBPE`, used by the encoding methods to skip the hashmap lookup for the hot initial adjacent-pair scan in both `_byte_pair_merge` (linear, pieces < 100 bytes) and `_byte_pair_merge_large` (heap-based, pieces ≥ 100 bytes). Subsequent merges (3+ byte spans) still go through the encoder hashmap; those keys don't fit in a u16 anyway.

Token output is byte-identical to vanilla. The optimization changes only how the initial 2-byte pair scan is implemented.

## Headline result

**+6.2% size-weighted aggregate `encode_ordinary` throughput** across 104 MiB of corpus on this codebase. Biggest wins on CJK Wikipedia (+8.6% to +13.8%) and FLORES multilingual (+7.8% to +7.9%) where the merger dominates encode time. Slight regression on dense numeric content (-1.3%) and roughly flat on Python source (-0.8% to -3.0%).

Apple M4 base (4P + 6E cores), single-thread `encode_ordinary` via Python wrapper, 3 rounds × 5 iterations per round, alternating between vanilla and patched runs (to control for thermal drift on the CPU) across vanilla (PyPI tiktoken 0.13.0) and this patched branch to control thermal drift.

Full per-corpus table in the appendix.

## Correctness

Two layers of byte-equality verification:

1. **Rust path-equivalence tests** (added in this PR, in `pair_table_equivalence` module): assert `byte_pair_encode` and `byte_pair_encode_with_table` produce identical output for piece lengths spanning the 100-byte linear-vs-heap dispatch cutoff (1, 2, 50, 98, 99, 100, 101, 200, 500, 1000), plus repeated-pair stress tests. 6 new tests, all pass alongside the 2 pre-existing tests.
2. **Full-corpus byte-equality** across all four built-in encodings (`r50k_base`, `p50k_base`, `cl100k_base`, `o200k_base`) on ~238 MiB of text (32 files: multilingual Wikipedia, code samples, FLORES-200, procedural numeric / repetition / long-piece stress). Token sequence sha256 matches between vanilla PyPI tiktoken and this patched fork on **all 128 (encoding × file) pairs**.

## Disclosures

- **+256 KB heap per `CoreBPE` instance**, built once at construction. Read-only after init, so Linux fork-based serving keeps it copy-on-write shared. For typical use (one tokenizer per process) the cost is invisible; multi-tokenizer-per-process systems should know.
- **Construction overhead is sub-millisecond.** Under 1 ms on the largest vocab (o200k_base, ~200k entries), within measurement noise on smaller ones. Full table in the appendix.

## Backward compatibility

- New `pair_table` field on `CoreBPE` is private to the module. External code constructs via `CoreBPE::new` as before; no API change visible to users.
- `_byte_pair_merge` and `_byte_pair_merge_large` gain an optional `pair_table: Option<&[Rank; 65536]>` parameter. Both are private functions; signature change is internal only.
- `byte_pair_encode` and `byte_pair_split` (public) keep their existing signatures and pass `None` internally, preserving back-compat for external Rust users.
- A new private helper `byte_pair_encode_with_table` is added (parallel to `byte_pair_encode`) for `CoreBPE` methods to use without changing the public function.
- No new public APIs, no behavior changes, no dependency additions.

## Testing

- **Rust**: `cargo test` passes 8/8 tests (2 pre-existing + 6 new path-equivalence tests covering both the linear and heap merge paths).
- **Python**: `pytest tests/` passes 33/33 (hypothesis-based property tests on r50k_base + cl100k_base, roundtrip tests, batch encoding, catastrophic-repetition stress, special tokens, pickling).
- **Byte-equality**: ~238 MiB curated corpus across 4 encodings yields identical token sequences vs vanilla PyPI tiktoken (sha256 hash match on all 128 pairs).

---

## Appendix

### A. Methodology

Apple M4 base (4P + 6E cores). Single-thread `encode_ordinary` via tiktoken's Python wrapper (which is itself a thin PyO3 binding around the Rust `CoreBPE::encode_ordinary`). 3 rounds × 5 iterations per round per file, alternating between vanilla and patched runs (to control for thermal drift on the CPU) between vanilla and patched to control thermal drift. Median across iterations within a round, then median across rounds; aggregate is `sum(bytes) / sum(median_times)`.

Vanilla side: PyPI `tiktoken==0.13.0` (installed from the package index in a clean venv).
Patched side: editable install of this branch (`pip install -e .`).

Byte-equality validated by encoding the full ~238 MiB curated corpus with both implementations and verifying token sequence sha256 hashes match across all (encoding × file) pairs.

### B. Corpora used in this PR's measurements

8 files for the perf bench (selected to cover diverse content):

| Corpus | Tier | Source | What it tests |
|---|---|---|---|
| `wiki_zh` | 1 MB & 15 MB | [wikimedia/wikipedia](https://huggingface.co/datasets/wikimedia/wikipedia) (zh) | Chinese Wikipedia, CJK-heavy |
| `flores200` | 1 MB & 15 MB | [Meta FLORES-200](https://github.com/facebookresearch/flores) | Concatenated devtest of 200 languages |
| `code_python` | 1 MB & 15 MB | [bigcode/the-stack-smol](https://huggingface.co/datasets/bigcode/the-stack-smol) | Python source code |
| `wiki_en` | 15 MB | [wikimedia/wikipedia](https://huggingface.co/datasets/wikimedia/wikipedia) (en) | English Wikipedia |
| `synthetic_numeric` | 1 MB | procedural (CSV / JSON / hex / UUIDs / IPv4 / dates) | Numeric-heavy content where 2-byte digit pairs are rare in the encoder |

The byte-equality run used a larger 32-file corpus: 16 files at 1 MB each (the per-file content listed above, plus code_go/javascript/rust, FLORES, wiki_ar/hi/ja/ru, wikitext_103, plus 4 procedural stress corpora: stress_doc, synthetic_numeric, merger_long_pieces, merger_repeated_pieces) and the 15 MB equivalents.

### C. Procedural corpora (detail + samples)

The four procedural corpora are generated locally. Each targets a specific algorithmic regime.

**`stress_doc`**: mixed-content document (random words, numbers, punctuation) with no paragraph breaks. Probes the long-input regime where fancy_regex can hit catastrophic-backtracking patterns.

```
sdmrulm ljwotlewvjc ) pnojbbyvh qzvrqbvlqsi ) wubpj bzrhxsjlmkuj . ; !
lpdcuvdauvu mysvwkscfyk ( 5492019 54359 evszryfefjz lba - - iflkgcfokjce
inodggcm 61 ? fsmqhrhm 98595 - 655044427 8691240 . yqvpa ...
```

**`synthetic_numeric`**: procedurally generated CSV rows, JSON logs, hex dumps, ISO timestamps, IPv4 addresses, and UUIDs.

```
57.12.140.125
{"k0":67.66994874229113,"k1":91161,"k2":23.266089339073957}
649.8844,236696312,805.8193,298362082,379.9273,"item711"
0x1e14ae531acfdd67d25aba1a8374eb35c0dc61e9b37ea22b8b695f27cd22a969...
58478be9-3761-a56d-0aa0-bc138227d1cd
Mon Dec 11 2020 01:37:30 UTC
```

**`merger_long_pieces`**: random alphanumeric runs of 100 to 500 bytes per piece. Hits the `_byte_pair_merge_large` heap path.

```
GRhxrnJgWQsNKVPwvrjFKqt6YrvfDliUWc7QSTR0YwDCXjD9T9M8Tra2JLIr6IzwgnS9
VPDi5TaO5deAlGQ18dD889UWuXeEys2Btiii5yvBqJiUFwcoEF1Q9Ci5wg74ja4z... (continues)
```

**`merger_repeated_pieces`**: ~10 unique pieces of 20 to 50 bytes, sampled with repetition.

```
uieahkwaxsqlfhgqyfazpgmefbcszuerrswx vjkjswbpvrgjxfyknsrpwqxqpbxffbqjqvyuvjbu
mxokvbjscokfktrpukpcrrquzszrhwrqdoioyjado nytzghujarzemafrxxwgcffslrhsfxqom
eyktdqsjntsjmhgcgtxwewy eyktdqsjntsjmhgcgtxwewy ...   (same piece, repeats)
```

### D. Per-file throughput (single-thread `encode_ordinary`, o200k_base)

Median across 3 rounds × 5 iterations per round, alternating between vanilla and patched runs (to control for thermal drift on the CPU).

| File | Vanilla (MiB/s) | Patched (MiB/s) | Δ |
|---|---:|---:|---:|
| `wiki_zh` (1 MB)            | 18.5 | 21.1 | **+13.8%** |
| `flores200` (1 MB)          | 23.9 | 25.7 | **+7.9%**  |
| `wiki_zh` (15 MB)           | 18.3 | 19.9 | **+8.6%**  |
| `flores200` (15 MB)         | 21.6 | 23.3 | **+7.8%**  |
| `wiki_en` (15 MB)           | 29.2 | 30.2 | **+3.4%**  |
| `code_python` (15 MB)       | 25.7 | 25.5 | -0.8%      |
| `synthetic_numeric` (1 MB)  | 16.3 | 16.1 | -1.3%      |
| `code_python` (1 MB)        | 25.9 | 25.1 | -3.0%      |
| **Aggregate (size-weighted, 104 MiB)** | **22.8** | **24.2** | **+6.2%** |

Slight regression on dense numeric content is expected: most 2-byte digit pairs aren't in the encoder vocab (`Rank::MAX` in the table), so the table-lookup work doesn't avoid as many useful hashmap calls. Code is dominated by `byte_pair_encode_with_table` cases that bypass the hot path (pieces matching tokens directly), so the win is small there too.

### E. Construction-time overhead (per-encoding)

Measured separately, criterion 100 samples × 5 s on Apple M4:

| Encoding | Vocab | Vanilla | + pair table | Δ |
|---|---:|---:|---:|---:|
| `o200k_base` | ~200k | 48.7 ms | 49.6 ms | +0.9 ms |
| `cl100k_base` | ~100k | 23.1 ms | 23.4 ms | +0.3 ms |
| `p50k_base` | ~50k | 11.4 ms | 11.3 ms | noise |
| `r50k_base` | ~50k | 11.2 ms | 11.5 ms | +0.3 ms |

Scales linearly with vocab size (one pass over the encoder entries). Sub-millisecond on the largest vocab.
