### PR TITLE
Recognise gpt-5.1 model identifier (Fixes #464)

### DIFF
--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -19,6 +19,12 @@ def test_encoding_for_model():
     assert enc.name == "o200k_base"
     enc = tiktoken.encoding_for_model("gpt-oss-120b")
     assert enc.name == "o200k_harmony"
+    # Regression for #464: a dotted minor like 'gpt-5.1' does not start
+    # with the 'gpt-5-' prefix, so it needs its own entry / prefix.
+    enc = tiktoken.encoding_for_model("gpt-5.1")
+    assert enc.name == "o200k_base"
+    enc = tiktoken.encoding_for_model("gpt-5.1-2025-11")
+    assert enc.name == "o200k_base"
 
 
 def test_optional_blobfile_dependency():

--- a/tiktoken/model.py
+++ b/tiktoken/model.py
@@ -9,6 +9,12 @@ MODEL_PREFIX_TO_ENCODING: dict[str, str] = {
     "o3-": "o200k_base",
     "o4-mini-": "o200k_base",
     # chat
+    # NB: list 'gpt-5.1-' before 'gpt-5-' so that a dotted minor like
+    # 'gpt-5.1-2025-11' is matched by its own prefix rather than failing the
+    # 'gpt-5-' check ('gpt-5.1-' does not start with 'gpt-5-'). For dict
+    # iteration order this is purely cosmetic — startswith() is correct either
+    # way — but it makes the intent explicit.
+    "gpt-5.1-": "o200k_base",
     "gpt-5-": "o200k_base",
     "gpt-4.5-": "o200k_base",
     "gpt-4.1-": "o200k_base",
@@ -32,6 +38,7 @@ MODEL_TO_ENCODING: dict[str, str] = {
     "o3": "o200k_base",
     "o4-mini": "o200k_base",
     # chat
+    "gpt-5.1": "o200k_base",
     "gpt-5": "o200k_base",
     "gpt-4.1": "o200k_base",
     "gpt-4o": "o200k_base",


### PR DESCRIPTION
## Summary

Fixes #464. `encoding_for_model("gpt-5.1")` currently raises `KeyError`
because the prefix table only contains `"gpt-5-"`, and `"gpt-5.1"` does
not start with `"gpt-5-"` (the literal hyphen mismatches the dot — this
is the same shape that caused #464 to be filed).

This change adds `"gpt-5.1"` (exact) and `"gpt-5.1-"` (versioned
variant) to the o200k_base mappings, alongside the existing `"gpt-5"` /
`"gpt-5-"` pair. Per OpenAI's GPT-5.1 migration note
(https://platform.openai.com/docs/guides/latest-model#migrating-from-other-models-to-gpt-5-1)
the model is documented as a drop-in replacement for GPT-5, so the
encoding choice mirrors GPT-5's.

A short code comment in `MODEL_PREFIX_TO_ENCODING` notes the
ordering rationale (purely cosmetic given `startswith` semantics, but
makes the intent explicit for the next person editing the table).

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
git clone https://github.com/openai/tiktoken.git /tmp/tt-464 && cd /tmp/tt-464
pip install -e . pytest

# BEFORE — on origin/main, gpt-5.1 raises KeyError
git checkout main
python -c "
import tiktoken
print(tiktoken.encoding_for_model('gpt-5').name)
try:
    print(tiktoken.encoding_for_model('gpt-5.1').name)
except KeyError as e:
    print('FAIL:', e)
"
# Expected: gpt-5 -> o200k_base; gpt-5.1 -> KeyError

# AFTER — on this branch, gpt-5.1 maps to o200k_base
git fetch https://github.com/jbbqqf/tiktoken.git feat/464-gpt-5.1-encoding
git checkout FETCH_HEAD
pip install -e .
python -c "
import tiktoken
for m in ['gpt-5', 'gpt-5.1', 'gpt-5.1-2025-11', 'gpt-5-mini']:
    print(m, '->', tiktoken.encoding_for_model(m).name)
"
# Expected: all four map to o200k_base
```

## What I ran locally

```
$ pytest tests/test_misc.py::test_encoding_for_model -v
tests/test_misc.py::test_encoding_for_model PASSED

$ pytest
============== 33 passed in 1.80s ==============
```

Verified the new test fails on `origin/main` (before the `tiktoken/model.py`
patch is applied) with `KeyError: 'Could not automatically map gpt-5.1
to a tokeniser'`, and passes after the patch.

## Edge cases

| Input | Behavior before | Behavior after |
|---|---|---|
| `"gpt-5"` | `o200k_base` (exact match) | unchanged |
| `"gpt-5-mini"` | `o200k_base` via `gpt-5-` prefix | unchanged |
| `"gpt-5.1"` | `KeyError` | `o200k_base` (exact match) |
| `"gpt-5.1-2025-11"` | `KeyError` | `o200k_base` via `gpt-5.1-` prefix |
| `"gpt-5.2"` (hypothetical future) | `KeyError` | still `KeyError` (intentional — wait for explicit OpenAI doc) |
| Any non-`gpt-5` model | unchanged | unchanged |

The change is additive (two new dict entries plus a comment); existing
mappings are untouched.

---

*PR drafted with assistance from Claude Code (Anthropic). The change
was reviewed manually against `tiktoken/model.py` and the OpenAI
migration doc linked above. The reproducer block above is the one I
used during development; reviewers can paste it verbatim.*
