### PR TITLE
Avoid panic when byte_pair_encode is given an empty piece

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,6 +198,9 @@ fn _byte_pair_merge(ranks: &HashMap<Vec<u8>, Rank>, piece: &[u8]) -> Vec<(usize,
 pub fn byte_pair_encode(piece: &[u8], ranks: &HashMap<Vec<u8>, Rank>) -> Vec<Rank> {
     let piece_len = piece.len();
 
+    if piece_len == 0 {
+        return vec![];
+    }
     if piece_len == 1 {
         return vec![ranks[piece]];
     }
@@ -680,10 +683,16 @@ mod tests {
     use fancy_regex::Regex;
     use rustc_hash::FxHashMap as HashMap;
 
-    use crate::{Rank, byte_pair_split};
+    use crate::{Rank, byte_pair_encode, byte_pair_split};
 
     fn setup_ranks() -> HashMap<Vec<u8>, Rank> {
         HashMap::from_iter([(b"ab".to_vec(), 0), (b"cd".to_vec(), 1)])
+    }
+
+    #[test]
+    fn test_empty_piece() {
+        let ranks = setup_ranks();
+        assert_eq!(byte_pair_encode(b"", &ranks), Vec::<Rank>::new());
     }
 
     #[test]


### PR DESCRIPTION
The public `byte_pair_encode` function special-cases pieces of length one but not length zero. An empty slice falls through to the `piece_len < 100` branch and calls `_byte_pair_merge`, where `for i in 0..piece.len() - 1` underflows `usize` and the subsequent `piece[i..i + 2]` slice index panics. This surfaces from Python too: `enc._encode_single_piece(b"")` raises a `PanicException` ("range end index 2 out of range for slice of length 0"), even though `enc.encode("")` already returns an empty list.

The fix is a small guard that returns an empty token vector for an empty piece, before the existing length-one case. This matches the natural result (no bytes produce no tokens) and keeps `_byte_pair_merge` from ever receiving a zero-length slice. Encoding behaviour for all non-empty inputs is unchanged.

I added a `test_empty_piece` regression test next to the existing byte pair tests. It panics on `main` and passes with this change. `cargo test` (3 passed), the Python suite via `pip install -e .` (33 passed), and `cargo fmt --check` are all green.