### PR TITLE
Remove test-skip comment for macOS arm64

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,9 +33,6 @@ skip = [
   "*-win32",
 ]
 macos.archs = ["x86_64", "arm64"]
-# When cross-compiling on Intel, it is not possible to test arm64 wheels.
-# Warnings will be silenced with following CIBW_TEST_SKIP
-test-skip = "*-macosx_arm64"
 
 before-test = "pip install pytest hypothesis"
 test-command = "pytest {project}/tests --import-mode=append"


### PR DESCRIPTION
Minor configuration change to remove the `test-skip` setting that previously skipped tests for `arm64` macOS wheels.

It seems there was an assumption that the MacOS image on GitHub Action runners was Intel based, but in fact the latest versions have been running Arm based MacOS runners for a while.

Testing this out seem to run fine on arm, no warnings. This has been cross compiling for x86 while running on Arm based hardware without a problem.