### PR TITLE
build: remove outdated arm64 test-skip (fixes #562)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,9 +33,6 @@ skip = [
   "*-win32",
 ]
 macos.archs = ["x86_64", "arm64"]
-# When cross-compiling on Intel, it is not possible to test arm64 wheels.
-# Warnings will be silenced with following CIBW_TEST_SKIP
-test-skip = "*-macosx_arm64"
-
+# arm64 macOS wheels are now tested natively on GitHub Actions arm64 runners.
 before-test = "pip install pytest hypothesis"
 test-command = "pytest {project}/tests --import-mode=append"


### PR DESCRIPTION
## Summary

Fixes #562 — removes the outdated `test-skip = "*-macosx_arm64"` from cibuildwheel config.

## Rationale

GitHub Actions now provides native arm64 macOS runners. The original test-skip was added because cross-compiling on Intel made arm64 testing impossible. This is no longer the case.

## Change

```diff
-# When cross-compiling on Intel, it is not possible to test arm64 wheels.
-# Warnings will be silenced with following CIBW_TEST_SKIP
-test-skip = "*-macosx_arm64"
+# arm64 macOS wheels are now tested natively on GitHub Actions arm64 runners.
```

## Verification

- Confirmed GitHub Actions supports native `macos-latest` arm64 runners
- No other configuration changes needed