### PR TITLE
fix: use user-private cache directory to prevent cache poisoning on shared systems

### DIFF
--- a/tests/test_cache_security.py
+++ b/tests/test_cache_security.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import hashlib
+import os
+import stat
+import tempfile
+
+import pytest
+
+from tiktoken.load import _default_cache_dir, read_file_cached
+
+
+@pytest.fixture()
+def isolated_cache(tmp_path, monkeypatch):
+    cache_dir = str(tmp_path / "tiktoken-cache")
+    monkeypatch.setenv("TIKTOKEN_CACHE_DIR", cache_dir)
+    return cache_dir
+
+
+@pytest.fixture()
+def default_cache(monkeypatch):
+    monkeypatch.delenv("TIKTOKEN_CACHE_DIR", raising=False)
+    monkeypatch.delenv("DATA_GYM_CACHE_DIR", raising=False)
+
+
+class TestDefaultCacheDir:
+    def test_respects_xdg_cache_home(self, monkeypatch):
+        monkeypatch.setenv("XDG_CACHE_HOME", "/custom/cache")
+        monkeypatch.delenv("LOCALAPPDATA", raising=False)
+        assert _default_cache_dir() == "/custom/cache/tiktoken"
+
+    def test_falls_back_to_home_dot_cache(self, monkeypatch):
+        monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+        monkeypatch.delenv("LOCALAPPDATA", raising=False)
+        result = _default_cache_dir()
+        assert result.endswith(os.path.join(".cache", "tiktoken"))
+
+    def test_not_in_tmp(self, monkeypatch):
+        monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+        monkeypatch.delenv("LOCALAPPDATA", raising=False)
+        result = _default_cache_dir()
+        assert tempfile.gettempdir() not in result
+
+
+class TestCacheDirPermissions:
+    def test_cache_dir_created_with_restricted_permissions(self, tmp_path, monkeypatch):
+        cache_dir = str(tmp_path / "new-cache")
+        monkeypatch.setenv("TIKTOKEN_CACHE_DIR", cache_dir)
+
+        test_file = str(tmp_path / "test_data.txt")
+        with open(test_file, "wb") as f:
+            f.write(b"test data")
+
+        read_file_cached(test_file, expected_hash=None)
+
+        dir_stat = os.stat(cache_dir)
+        mode = stat.S_IMODE(dir_stat.st_mode)
+        assert mode & stat.S_IRWXG == 0, "Group should have no permissions"
+        assert mode & stat.S_IRWXO == 0, "Others should have no permissions"
+
+
+class TestHashVerification:
+    def test_valid_hash_returns_data(self, isolated_cache, tmp_path):
+        test_data = b"hello tiktoken"
+        test_file = str(tmp_path / "source.txt")
+        with open(test_file, "wb") as f:
+            f.write(test_data)
+
+        expected_hash = hashlib.sha256(test_data).hexdigest()
+        result = read_file_cached(test_file, expected_hash=expected_hash)
+        assert result == test_data
+
+        result2 = read_file_cached(test_file, expected_hash=expected_hash)
+        assert result2 == test_data
+
+    def test_invalid_hash_rejects_download(self, isolated_cache, tmp_path):
+        test_data = b"hello tiktoken"
+        test_file = str(tmp_path / "source.txt")
+        with open(test_file, "wb") as f:
+            f.write(test_data)
+
+        with pytest.raises(ValueError, match="Hash mismatch"):
+            read_file_cached(test_file, expected_hash="badhash" * 8)
+
+    def test_tampered_cache_is_refetched(self, isolated_cache, tmp_path):
+        test_data = b"original data"
+        test_file = str(tmp_path / "source.txt")
+        with open(test_file, "wb") as f:
+            f.write(test_data)
+
+        expected_hash = hashlib.sha256(test_data).hexdigest()
+        read_file_cached(test_file, expected_hash=expected_hash)
+
+        cache_key = hashlib.sha1(test_file.encode()).hexdigest()
+        cache_path = os.path.join(isolated_cache, cache_key)
+        with open(cache_path, "wb") as f:
+            f.write(b"tampered data")
+
+        result = read_file_cached(test_file, expected_hash=expected_hash)
+        assert result == test_data
+
+    def test_no_hash_logs_warning(self, isolated_cache, tmp_path, caplog):
+        import logging
+
+        test_data = b"some data"
+        test_file = str(tmp_path / "source.txt")
+        with open(test_file, "wb") as f:
+            f.write(test_data)
+
+        read_file_cached(test_file, expected_hash=None)
+
+        with caplog.at_level(logging.WARNING, logger="tiktoken"):
+            read_file_cached(test_file, expected_hash=None)
+
+        assert "without hash verification" in caplog.text

--- a/tiktoken/load.py
+++ b/tiktoken/load.py
@@ -2,7 +2,24 @@ from __future__ import annotations
 
 import base64
 import hashlib
+import logging
 import os
+import sys
+
+logger = logging.getLogger("tiktoken")
+
+
+def _default_cache_dir() -> str:
+    if sys.platform == "win32":
+        appdata = os.environ.get("LOCALAPPDATA")
+        if appdata:
+            return os.path.join(appdata, "tiktoken", "cache")
+
+    xdg = os.environ.get("XDG_CACHE_HOME")
+    if xdg:
+        return os.path.join(xdg, "tiktoken")
+
+    return os.path.join(os.path.expanduser("~"), ".cache", "tiktoken")
 
 
 def read_file(blobpath: str) -> bytes:
@@ -39,9 +56,7 @@ def read_file_cached(blobpath: str, expected_hash: str | None = None) -> bytes:
     elif "DATA_GYM_CACHE_DIR" in os.environ:
         cache_dir = os.environ["DATA_GYM_CACHE_DIR"]
     else:
-        import tempfile
-
-        cache_dir = os.path.join(tempfile.gettempdir(), "data-gym-cache")
+        cache_dir = _default_cache_dir()
         user_specified_cache = False
 
     if cache_dir == "":
@@ -54,7 +69,15 @@ def read_file_cached(blobpath: str, expected_hash: str | None = None) -> bytes:
     if os.path.exists(cache_path):
         with open(cache_path, "rb", buffering=0) as f:
             data = f.read()
-        if expected_hash is None or check_hash(data, expected_hash):
+        if expected_hash is not None:
+            if check_hash(data, expected_hash):
+                return data
+        else:
+            logger.warning(
+                "Loading cached file %s without hash verification. "
+                "Consider providing an expected_hash for integrity checking.",
+                cache_path,
+            )
             return data
 
         # the cached file does not match the hash, remove it and re-fetch
@@ -73,7 +96,7 @@ def read_file_cached(blobpath: str, expected_hash: str | None = None) -> bytes:
     import uuid
 
     try:
-        os.makedirs(cache_dir, exist_ok=True)
+        os.makedirs(cache_dir, mode=0o700, exist_ok=True)
         tmp_filename = cache_path + "." + str(uuid.uuid4()) + ".tmp"
         with open(tmp_filename, "wb") as f:
             f.write(contents)


### PR DESCRIPTION
## Summary

Fixes #500. Addresses two security vulnerabilities in `tiktoken/load.py`:

1. **Cache poisoning via shared temp directory (CWE-377/CWE-379):** The default cache directory was `/tmp/data-gym-cache/`, which is world-writable on multi-user Linux systems. An attacker could pre-populate poisoned BPE data with predictable filenames (`sha1(url)`), causing subsequent users to load attacker-controlled tokenizer data.

2. **Silent cache loading without hash verification (CWE-345):** When `expected_hash` is `None` (e.g., custom encodings), cached files were loaded without any integrity check or warning.

### Changes

- **Default cache directory** changed from `tempfile.gettempdir() + "/data-gym-cache"` to a user-private location:
  - Linux/macOS: `$XDG_CACHE_HOME/tiktoken` or `~/.cache/tiktoken`
  - Windows: `%LOCALAPPDATA%\tiktoken\cache`
- **Cache directory permissions** set to `0o700` (owner-only) on creation
- **Warning logged** when loading cached files without hash verification
- **Full backward compatibility**: `TIKTOKEN_CACHE_DIR` and `DATA_GYM_CACHE_DIR` env vars continue to work as before

### Why not migrate the old cache?

Files in `/tmp/data-gym-cache/` could already be poisoned, so we intentionally do not copy them. Users will re-download encodings once into the secure location.

## Test plan

- [x] New `tests/test_cache_security.py` with 8 tests covering:
  - XDG_CACHE_HOME respected
  - Default dir not in `/tmp`
  - Cache dir created with restricted permissions (no group/other access)
  - Hash verification: valid hash, invalid hash, tampered cache re-fetch
  - Warning logged when loading without hash
- [x] All existing tests pass (`test_misc.py`, `test_simple_public.py`, `test_helpers.py`)
- [x] Manual verification: `tiktoken.get_encoding('cl100k_base')` works correctly with new cache location