### PR TITLE
fix: remove unused import in tests module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -677,7 +677,6 @@ impl CoreBPE {
 
 #[cfg(test)]
 mod tests {
-    use fancy_regex::Regex;
     use rustc_hash::FxHashMap as HashMap;
 
     use crate::{Rank, byte_pair_split};


### PR DESCRIPTION
`fancy_regex::Regex` was imported in the test module but never used, producing a compiler warning. Removed it; tests still pass cleanly.