### PR TITLE
fix(py): make encode_with_unstable handle surrogates like encode (#541)

### DIFF
--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -110,6 +110,17 @@ def test_encode_surrogate_pairs():
     assert enc.encode("\ud83d") == enc.encode("�")
 
 
+def test_encode_with_unstable_surrogate_pairs():
+    enc = tiktoken.get_encoding("cl100k_base")
+
+    # would raise UnicodeEncodeError before the fix in core.py
+    enc.encode_with_unstable("\ud83d\udc4d")
+    enc.encode_with_unstable("\ud83d")
+
+    assert enc.encode("\ud83d\udc4d") == enc.encode("👍")
+    assert enc.encode("\ud83d") == enc.encode("�")
+
+
 @pytest.mark.parametrize("make_enc", ENCODING_FACTORIES)
 def test_catastrophically_repetitive(make_enc: Callable[[], tiktoken.Encoding]):
     enc = make_enc()

--- a/tiktoken/core.py
+++ b/tiktoken/core.py
@@ -240,7 +240,11 @@ class Encoding:
             if match := _special_token_regex(disallowed_special).search(text):
                 raise_disallowed_special_token(match.group())
 
-        return self._core_bpe.encode_with_unstable(text, allowed_special)
+        try:
+            return self._core_bpe.encode_with_unstable(text, allowed_special)
+        except UnicodeEncodeError:
+            text = text.encode("utf-16", "surrogatepass").decode("utf-16", "replace")
+            return self._core_bpe.encode_with_unstable(text, allowed_special)
 
     def encode_single_token(self, text_or_bytes: str | bytes) -> int:
         """Encodes text corresponding to a single token to its token value.


### PR DESCRIPTION
## Summary

Fixes #541.

`Encoding.encode` and `Encoding.encode_ordinary` already catch `UnicodeEncodeError` from the Rust BPE layer and retry after a UTF-16 `surrogatepass` + `replace` round-trip. `Encoding.encode_with_unstable` did not, so the same inputs that worked through `encode` raised `UnicodeEncodeError`.

This PR mirrors the same try/except/repair pattern in `encode_with_unstable` so all three encode paths accept the same surrogate inputs.

## Repro (before)

```python
import tiktoken

enc = tiktoken.get_encoding("cl100k_base")

enc.encode("\ud83d\udc4d")               # works 
enc.encode_with_unstable("\ud83d\udc4d") # UnicodeEncodeError before but works 

enc.encode("\ud83d")                     # works
enc.encode_with_unstable("\ud83d")       # UnicodeEncodeError

```

## Changes
Wrap self._core_bpe.encode_with_unstable(...) in the same surrogate repair logic used by encode() in tiktoken/core.py
Add test_encode_with_unstable_surrogate_pairs in tests/test_encoding.py


## Test Plan
```python
def test_encode_with_unstable_surrogate_pairs():
    enc = tiktoken.get_encoding("cl100k_base")

    # would raise UnicodeEncodeError before the fix in core.py
    enc.encode_with_unstable("\ud83d\udc4d")
    enc.encode_with_unstable("\ud83d")

    assert enc.encode("\ud83d\udc4d") == enc.encode("👍")
    assert enc.encode("\ud83d") == enc.encode("�")
```

