### PR TITLE
fix(model): add exact mapping for gpt-4.5

### DIFF
--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -19,6 +19,13 @@ def test_encoding_for_model():
     assert enc.name == "o200k_base"
     enc = tiktoken.encoding_for_model("gpt-oss-120b")
     assert enc.name == "o200k_harmony"
+    # Regression: "gpt-4.5" (exact name without a version suffix) must resolve
+    # via MODEL_TO_ENCODING, not the "gpt-4.5-" prefix which requires a trailing
+    # hyphen and therefore doesn't match the bare model name.
+    enc = tiktoken.encoding_for_model("gpt-4.5")
+    assert enc.name == "o200k_base"
+    enc = tiktoken.encoding_for_model("gpt-4.5-preview")
+    assert enc.name == "o200k_base"
 
 
 def test_optional_blobfile_dependency():

--- a/tiktoken/model.py
+++ b/tiktoken/model.py
@@ -33,6 +33,7 @@ MODEL_TO_ENCODING: dict[str, str] = {
     "o4-mini": "o200k_base",
     # chat
     "gpt-5": "o200k_base",
+    "gpt-4.5": "o200k_base",
     "gpt-4.1": "o200k_base",
     "gpt-4o": "o200k_base",
     "gpt-4": "cl100k_base",


### PR DESCRIPTION
`encoding_for_model("gpt-4.5")` raises a `KeyError` today:

```python
>>> import tiktoken
>>> tiktoken.encoding_for_model("gpt-4.5")
KeyError: 'Could not automatically map gpt-4.5 to a tokeniser. ...'
```

**Root cause:** `MODEL_PREFIX_TO_ENCODING` contains `"gpt-4.5-"` (note the trailing hyphen), which correctly handles versioned variants like `gpt-4.5-preview`. However, the bare model name `"gpt-4.5"` does not start with `"gpt-4.5-"` — the trailing hyphen is never matched — so it falls through to the `KeyError` path.

This is the same shape as the `gpt-5.1` issue (#464 / PR #554). Every other dot-minor model (`gpt-5`, `gpt-4.1`, `gpt-4o`) has both an exact entry in `MODEL_TO_ENCODING` *and* a versioned prefix. `gpt-4.5` was missing the exact entry.

**Fix:** add `"gpt-4.5": "o200k_base"` to `MODEL_TO_ENCODING`, consistent with all peer models.

**Verified locally:**
```python
>>> tiktoken.encoding_for_model("gpt-4.5").name
'o200k_base'
>>> tiktoken.encoding_for_model("gpt-4.5-preview").name  # prefix still works
'o200k_base'
```

*This contribution was made with AI assistance.*