### PR TITLE
fix: reject encoders missing single-byte tokens to prevent reachable panic (#568)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -640,6 +640,26 @@ impl CoreBPE {
             decoder.len()
         );
 
+        // A complete byte-level BPE encoder must contain a token for every single byte.
+        // `byte_pair_encode` reduces a piece down to the tokens it is made of, and any leftover
+        // that did not merge is a single byte looked up directly in the encoder. If that byte is
+        // missing, the `ranks[...]` indexing panics. With an untrusted or malformed encoder this is
+        // a reachable panic (denial of service) during tokenization, so reject such encoders here
+        // with a clear error instead of letting them blow up later inside `encode`.
+        let missing_bytes: Vec<u8> = (0u16..=255)
+            .map(|b| b as u8)
+            .filter(|&b| !encoder.contains_key([b].as_slice()))
+            .collect();
+        if !missing_bytes.is_empty() {
+            return Err(format!(
+                "Encoder is missing tokens for {} single-byte value(s) (e.g. {:?}); a complete \
+                 byte-level BPE encoder must contain a token for every byte 0..=255.",
+                missing_bytes.len(),
+                &missing_bytes[..missing_bytes.len().min(8)],
+            )
+            .into());
+        }
+
         let special_tokens_decoder: HashMap<Rank, Vec<u8>> = special_tokens_encoder
             .iter()
             .map(|(k, v)| (*v, k.as_bytes().to_vec()))
@@ -680,10 +700,14 @@ mod tests {
     use fancy_regex::Regex;
     use rustc_hash::FxHashMap as HashMap;
 
-    use crate::{Rank, byte_pair_split};
+    use crate::{CoreBPE, Rank, byte_pair_split};
 
     fn setup_ranks() -> HashMap<Vec<u8>, Rank> {
         HashMap::from_iter([(b"ab".to_vec(), 0), (b"cd".to_vec(), 1)])
+    }
+
+    fn complete_byte_ranks() -> HashMap<Vec<u8>, Rank> {
+        (0u16..=255).map(|b| (vec![b as u8], b as Rank)).collect()
     }
 
     #[test]
@@ -698,5 +722,28 @@ mod tests {
         let ranks = setup_ranks();
         let res = byte_pair_split(b"abab", &ranks);
         assert_eq!(res, vec![b"ab", b"ab"]);
+    }
+
+    #[test]
+    fn test_new_rejects_encoder_missing_single_byte_tokens() {
+        // An encoder without single-byte tokens cannot break an arbitrary piece down to bytes,
+        // which previously led to a reachable panic inside `encode`. Construction must fail
+        // up front with a clear error instead.
+        let encoder = HashMap::from_iter([(b"ab".to_vec(), 0 as Rank)]);
+        let err = match CoreBPE::new_internal(encoder, HashMap::default(), "a") {
+            Ok(_) => panic!("expected construction to fail for an incomplete encoder"),
+            Err(e) => e,
+        };
+        assert!(
+            err.to_string().contains("single-byte"),
+            "unexpected error message: {err}"
+        );
+    }
+
+    #[test]
+    fn test_new_accepts_complete_byte_encoder() {
+        let mut encoder = complete_byte_ranks();
+        encoder.insert(b"ab".to_vec(), 256);
+        assert!(CoreBPE::new_internal(encoder, HashMap::default(), "a").is_ok());
     }
 }


### PR DESCRIPTION
## Summary

Fixes #568 — a reachable Rust panic (denial of service) when tokenizing with an untrusted/malformed encoder that is missing single-byte tokens.

**Root cause.** `byte_pair_encode` reduces a piece down to the tokens it is made of. Any segment that does not get merged is a single byte, looked up directly via `ranks[&piece[..]]`. BPE only ever merges pairs that exist in the encoder, so the only lookups that can fail are single bytes that have no token. When such a byte is encountered, the indexing panics:

```rust
// src/lib.rs, byte_pair_encode
if piece_len == 1 {
    return vec![ranks[piece]];          // panics if this byte has no token
}
...
.map(|part| ranks[&piece[part[0].0..part[1].0]])  // same
```

With an untrusted or malformed encoder (e.g. a custom `mergeable_ranks` passed to `tiktoken.Encoding`), tokenizing ordinary text reaches this panic and kills the process — a denial of service rather than a catchable error.

I confirmed the panic empirically with a `#[should_panic]` reproduction calling `byte_pair_encode(b"xyz", &ranks)` against an encoder lacking single-byte tokens.

## The fix

Validate **at construction** (`new_internal`, the single chokepoint behind `CoreBPE::new` and the Python `CoreBPE(...)` constructor) that the encoder contains a token for every byte `0..=255`. If any are missing, return a clear error instead of allowing a later panic. From Python this surfaces as a `ValueError` at load time.

A complete byte-level BPE encoder must define a token for every byte for tokenization to be total, and all standard tiktoken encoders (`gpt2`, `cl100k_base`, `o200k_base`, …) already include every single-byte token, so **no valid encoder is affected** — only malformed ones that would otherwise panic.

## Changes

- `new_internal`: reject encoders missing any single-byte token, with an error naming how many bytes are missing and a few examples.
- Tests: `test_new_rejects_encoder_missing_single_byte_tokens` and `test_new_accepts_complete_byte_encoder`.

## Test plan

- [x] `cargo test --lib` — all pass
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --lib` clean
- [x] Empirically reproduced the original panic before the fix

## Note for maintainers

This enforces the contract "a complete byte-level encoder defines all 256 single-byte tokens" at construction. Strictly, valid UTF-8 input can never contain a handful of byte values (0xC0, 0xC1, 0xF5–0xFF), so a minimal encoder could omit those and still tokenize all valid `&str` input. Requiring all 256 is the simpler, readable rule that matches every shipped encoder; happy to narrow the check to UTF-8-reachable bytes, or move it behind an explicit validation entry point, if you prefer.