### PR TITLE
Update PyO3 to 0.29

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ python = [
 ]
 
 [dependencies]
-pyo3 = { version = "0.28.3", default-features = false, features = [
+pyo3 = { version = "0.29.0", default-features = false, features = [
     "extension-module",
     "macros",
 ], optional = true }


### PR DESCRIPTION
Addresses RUSTSEC-2026-0176 and RUSTSEC-2026-0177.

I’m planning to patch the [`python-tiktoken` package in Fedora](https://src.fedoraproject.org/rpms/python-tiktoken), and this PR offers the change upstream.