### PR TITLE
fix: apply surrogate-pair fixup in encode_with_unstable

### DIFF
--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -110,6 +110,21 @@ def test_encode_surrogate_pairs():
     assert enc.encode("\ud83d") == enc.encode("�")
 
 
+def test_encode_with_unstable_surrogate_pairs():
+    enc = tiktoken.get_encoding("cl100k_base")
+
+    # encode_with_unstable must not raise UnicodeEncodeError for surrogate pairs
+    stable, completions = enc.encode_with_unstable("👍")
+    stable_via_surrogate, completions_via_surrogate = enc.encode_with_unstable("\ud83d\udc4d")
+    assert stable == stable_via_surrogate
+    assert completions == completions_via_surrogate
+
+    # lone surrogate treated the same as the replacement character
+    stable_lone, _ = enc.encode_with_unstable("\ud83d")
+    stable_replacement, _ = enc.encode_with_unstable("�")
+    assert stable_lone == stable_replacement
+
+
 @pytest.mark.parametrize("make_enc", ENCODING_FACTORIES)
 def test_catastrophically_repetitive(make_enc: Callable[[], tiktoken.Encoding]):
     enc = make_enc()

--- a/tiktoken/core.py
+++ b/tiktoken/core.py
@@ -240,7 +240,12 @@ class Encoding:
             if match := _special_token_regex(disallowed_special).search(text):
                 raise_disallowed_special_token(match.group())
 
-        return self._core_bpe.encode_with_unstable(text, allowed_special)
+        try:
+            return self._core_bpe.encode_with_unstable(text, allowed_special)
+        except UnicodeEncodeError:
+            # see comment in encode; same surrogate-pair fixup applied here
+            text = text.encode("utf-16", "surrogatepass").decode("utf-16", "replace")
+            return self._core_bpe.encode_with_unstable(text, allowed_special)
 
     def encode_single_token(self, text_or_bytes: str | bytes) -> int:
         """Encodes text corresponding to a single token to its token value.


### PR DESCRIPTION
Fixes #541.

`encode` and `encode_ordinary` both catch `UnicodeEncodeError` and re-encode the text through UTF-16 surrogatepass before retrying, so they handle strings containing surrogate pairs (e.g. `"👍"`) correctly. `encode_with_unstable` was missing the same try/except, causing it to raise `UnicodeEncodeError` on identical input.

**Change:** wrap the inner `_core_bpe.encode_with_unstable` call in the same try/except that `encode` uses.

**Test:** `test_encode_with_unstable_surrogate_pairs` in `tests/test_encoding.py` verifies that:
- A surrogate-pair string produces the same output as the equivalent codepoint (`"👍"`).
- A lone surrogate is treated as the replacement character, consistent with `encode`.