### PR TITLE
Return ValueError instead of panicking on duplicate mergeable_ranks

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -633,12 +633,14 @@ impl CoreBPE {
         let decoder: HashMap<Rank, Vec<u8>> =
             encoder.iter().map(|(k, v)| (*v, k.clone())).collect();
 
-        assert!(
-            encoder.len() == decoder.len(),
-            "Encoder and decoder must be of equal length. Encoder length: {}, decoder length: {}.\nMaybe you had duplicate token indices in your encoder?",
-            encoder.len(),
-            decoder.len()
-        );
+        if encoder.len() != decoder.len() {
+            return Err(format!(
+                "Encoder and decoder must be of equal length. Encoder length: {}, decoder length: {}.\nMaybe you had duplicate token indices in your encoder?",
+                encoder.len(),
+                decoder.len()
+            )
+            .into());
+        }
 
         let special_tokens_decoder: HashMap<Rank, Vec<u8>> = special_tokens_encoder
             .iter()

--- a/tests/test_duplicate_ranks.py
+++ b/tests/test_duplicate_ranks.py
@@ -1,0 +1,13 @@
+import pytest
+
+import tiktoken
+
+
+def test_duplicate_mergeable_ranks_raise_value_error():
+    with pytest.raises(ValueError):
+        tiktoken.Encoding(
+            name="duplicate_ranks",
+            pat_str=r".",
+            mergeable_ranks={b"a": 0, b"b": 0, b"c": 1},
+            special_tokens={},
+        )


### PR DESCRIPTION
### Problem

Constructing an `Encoding` with duplicate ranks in `mergeable_ranks` crashes with an uncatchable `pyo3_runtime.PanicException` instead of raising a normal `ValueError`:

```python
import tiktoken
tiktoken.Encoding(name="x", pat_str=r".", mergeable_ranks={b"a": 0, b"b": 0, b"c": 1}, special_tokens={})
# pyo3_runtime.PanicException: Encoder and decoder must be of equal length. ...
```

Because it is a panic rather than an exception, callers cannot handle it with `except ValueError` (or any normal `except`), and it can tear down the interpreter.

### Root cause

In `CoreBPE::new_internal` (`src/lib.rs`), the length mismatch between the encoder and the derived decoder - which happens when two tokens share a rank - is checked with a raw `assert!`. `new_internal` already returns `Result<Self, ...>` and surfaces regex errors cleanly via `Regex::new(pattern)?`, and `py.rs` maps that `Err` to `PyValueError`. The `assert!` panics before it can return through that path.

### Fix

Return an `Err` on the length mismatch so it flows through the existing `Result` path (and therefore the `PyValueError` mapping in `py.rs`) instead of panicking. The message is unchanged.

### Test

Adds `tests/test_duplicate_ranks.py`, which asserts that duplicate `mergeable_ranks` raise `ValueError`. Before the change it fails with `PanicException`; after, it passes.

Refs #87 (same crash, reported in 2023).
