### PR TITLE
Add CI support for Windows ARM64

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -60,6 +60,31 @@ jobs:
           name: cibw-wheels-aarch64-${{ matrix.os }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl
 
+  build_wheels_windows_arm64:
+    name: py${{ matrix.python-version }} on ${{ matrix.os }} (arm64)
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-11-arm]
+        python-version: [39, 310, 311, 312, 313, 313t, 314, 314t]
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@65b8265957fd86372d9689a0acdfd55813970d5d # v3.1.4
+        env:
+          CIBW_BUILD: "cp${{ matrix.python-version}}-*"
+          CIBW_ARCHS: ARM64
+          CIBW_ENABLE: cpython-freethreading
+
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: cibw-wheels-windows-arm64-${{ matrix.os }}-${{ strategy.job-index }}
+          path: ./wheelhouse/*.whl
+
   build_sdist:
     name: sdist
     runs-on: ubuntu-latest
@@ -86,7 +111,7 @@ jobs:
   join_artifacts:
     name: Join artifacts
     runs-on: ubuntu-latest
-    needs: [build_wheels, build_wheels_aarch64, build_sdist]
+    needs: [build_wheels, build_wheels_aarch64, build_wheels_windows_arm64, build_sdist]
     steps:
      - name: Merge artifacts
        uses: actions/upload-artifact/merge@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,5 +37,6 @@ macos.archs = ["x86_64", "arm64"]
 # Warnings will be silenced with following CIBW_TEST_SKIP
 test-skip = "*-macosx_arm64"
 
+# Hypothesis >=6.156 does not publish cp313t wheels yet. It will break the CI.
 before-test = "pip install pytest 'hypothesis<6.156'"
 test-command = "pytest {project}/tests --import-mode=append"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,5 +38,5 @@ macos.archs = ["x86_64", "arm64"]
 test-skip = "*-macosx_arm64"
 
 # Hypothesis >=6.156 does not publish cp313t wheels yet. It will break the CI.
-before-test = "pip install pytest 'hypothesis<6.156'"
+before-test = "pip install pytest \"hypothesis<6.156\""
 test-command = "pytest {project}/tests --import-mode=append"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,5 +37,5 @@ macos.archs = ["x86_64", "arm64"]
 # Warnings will be silenced with following CIBW_TEST_SKIP
 test-skip = "*-macosx_arm64"
 
-before-test = "pip install pytest hypothesis<6.156"
+before-test = "pip install pytest 'hypothesis<6.156'"
 test-command = "pytest {project}/tests --import-mode=append"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,5 +37,5 @@ macos.archs = ["x86_64", "arm64"]
 # Warnings will be silenced with following CIBW_TEST_SKIP
 test-skip = "*-macosx_arm64"
 
-before-test = "pip install pytest hypothesis"
+before-test = "pip install pytest hypothesis<6.156"
 test-command = "pytest {project}/tests --import-mode=append"


### PR DESCRIPTION
Hi @hauntsaninja, I'm from Microsoft and recently I'm working on improving Python ecosystem support for Windows on Arm. We need tiktoken to support Windows ARM64. So I submit these changes. Could you please help to review?

**CI/CD: Add Windows ARM64 wheel builds**
* [`.github/workflows/build_wheels.yml`](diffhunk://#diff-52d0610b43ce35e44510ae2d15d70668334378b01c1bdc774159cd3a33b71728R63-R87): Adds a new `build_wheels_windows_arm64` job to build wheels for Python versions 3.9 through 3.14 (including freethreading variants) on Windows ARM64 (`windows-11-arm`). The built wheels are uploaded as artifacts.
* [`.github/workflows/build_wheels.yml`](diffhunk://#diff-52d0610b43ce35e44510ae2d15d70668334378b01c1bdc774159cd3a33b71728L89-R114): Updates the `join_artifacts` job to include the new `build_wheels_windows_arm64` job in its dependencies, ensuring these new wheels are merged with the others.

**Testing: Pin hypothesis version**
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L40-R41): Pins the `hypothesis` dependency to `<6.156` in `before-test` to avoid CI failures for Python 3.13 freethreading, as newer versions do not publish compatible wheels yet.

**Build Wheels Pipeline Test Results**
https://github.com/chinazhangchao/tiktoken/actions/runs/29305569386