### PR TITLE
fix: map gpt-5.1 model names to o200k_base

### DIFF
--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -19,6 +19,9 @@ def test_encoding_for_model():
     assert enc.name == "o200k_base"
     enc = tiktoken.encoding_for_model("gpt-oss-120b")
     assert enc.name == "o200k_harmony"
+    # gpt-5.1 uses a dotted name and must not require a hyphenated prefix match
+    assert tiktoken.model.encoding_name_for_model("gpt-5.1") == "o200k_base"
+    assert tiktoken.model.encoding_name_for_model("gpt-5.1-2025-11-13") == "o200k_base"
 
 
 def test_optional_blobfile_dependency():

--- a/tiktoken/model.py
+++ b/tiktoken/model.py
@@ -9,6 +9,9 @@ MODEL_PREFIX_TO_ENCODING: dict[str, str] = {
     "o3-": "o200k_base",
     "o4-mini-": "o200k_base",
     # chat
+    # gpt-5.1 / gpt-5.2 style names use a dot, not a hyphen, so they do not
+    # match the "gpt-5-" prefix used for dated gpt-5-* snapshots.
+    "gpt-5.": "o200k_base",
     "gpt-5-": "o200k_base",
     "gpt-4.5-": "o200k_base",
     "gpt-4.1-": "o200k_base",
@@ -33,6 +36,7 @@ MODEL_TO_ENCODING: dict[str, str] = {
     "o4-mini": "o200k_base",
     # chat
     "gpt-5": "o200k_base",
+    "gpt-5.1": "o200k_base",
     "gpt-4.1": "o200k_base",
     "gpt-4o": "o200k_base",
     "gpt-4": "cl100k_base",


### PR DESCRIPTION
## Summary
`encoding_for_model("gpt-5.1")` raised `KeyError` because only exact `gpt-5` and the hyphenated `gpt-5-` prefix were mapped. The dotted `gpt-5.1` name matches neither.

### Changes
- Add exact `gpt-5.1` → `o200k_base`
- Add prefix `gpt-5.` → `o200k_base` for dated/future dotted 5.x names
- Extend unit tests for `gpt-5.1` and `gpt-5.1-…`

## Testing
- Pure mapping check for `gpt-5` / `gpt-5.1` / `gpt-5.1-2025-11-13` / `gpt-5-mini`
- Native `_tiktoken` extension not built in this environment; CI should run `tests/test_misc.py`

Fixes #578
