### PR TITLE
Avoid panic when byte_pair_encode is given an empty piece

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,6 +198,9 @@ fn _byte_pair_merge(ranks: &HashMap<Vec<u8>, Rank>, piece: &[u8]) -> Vec<(usize,
 pub fn byte_pair_encode(piece: &[u8], ranks: &HashMap<Vec<u8>, Rank>) -> Vec<Rank> {
     let piece_len = piece.len();
 
+    if piece_len == 0 {
+        return vec![];
+    }
     if piece_len == 1 {
         return vec![ranks[piece]];
     }
@@ -680,10 +683,17 @@ mod tests {
     use fancy_regex::Regex;
     use rustc_hash::FxHashMap as HashMap;
 
-    use crate::{Rank, byte_pair_split};
+    use crate::{Rank, byte_pair_encode, byte_pair_split};
 
     fn setup_ranks() -> HashMap<Vec<u8>, Rank> {
         HashMap::from_iter([(b"ab".to_vec(), 0), (b"cd".to_vec(), 1)])
+    }
+
+    #[test]
+    fn test_empty_piece() {
+        let ranks = setup_ranks();
+        let res = byte_pair_encode(b"", &ranks);
+        assert_eq!(res, Vec::<Rank>::new());
     }
 
     #[test]


### PR DESCRIPTION
`byte_pair_encode` special-cases a piece of length one but not length zero. An empty slice falls through to the `piece_len < 100` branch into `_byte_pair_merge`, where `for i in 0..piece.len() - 1` underflows `usize` and the following `piece[i..i + 2]` slice index panics.

This is reachable from Python:

```python
>>> enc = tiktoken.get_encoding("cl100k_base")
>>> enc.encode("")
[]
>>> enc._encode_single_piece(b"")
pyo3_runtime.PanicException: range end index 2 out of range for slice of length 0
```

`encode("")` already returns an empty list, so the panic is an inconsistency rather than intended behaviour. `byte_pair_split` handles the same situation explicitly with `assert!(piece.len() > 1)`.

The fix returns an empty vector for an empty piece, before the existing length-one check.

Added a regression test alongside the existing ones in `src/lib.rs`. Without the guard it panics at `src/lib.rs:149`; with it, `cargo test` passes 3/3.

Note: #559 proposed the same one-line guard. It was closed by its author without any maintainer response, so I do not believe the change was ever considered and rejected. Happy to close this if that is not the case.