### PR TITLE
fix: Unable to route GET requests through proxy

### DIFF
--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -1,0 +1,27 @@
+from tiktoken.load import read_file
+
+
+class FakeResponse:
+    content = b"fake content"
+
+    def raise_for_status(self):
+        pass
+
+
+class FakeSession:
+    def __init__(self):
+        self.requested_urls = []
+
+    def get(self, url):
+        self.requested_urls.append(url)
+        return FakeResponse()
+
+
+def test_read_file_uses_provided_session():
+    session = FakeSession()
+    url = "https://example.com/some-file"
+
+    data = read_file(url, session=session)
+
+    assert data == b"fake content"
+    assert session.requested_urls == [url]

--- a/tiktoken/load.py
+++ b/tiktoken/load.py
@@ -3,9 +3,13 @@ from __future__ import annotations
 import base64
 import hashlib
 import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import requests
 
 
-def read_file(blobpath: str) -> bytes:
+def read_file(blobpath: str, session: requests.Session | None = None) -> bytes:
     if "://" not in blobpath:
         with open(blobpath, "rb", buffering=0) as f:
             return f.read()
@@ -14,7 +18,7 @@ def read_file(blobpath: str) -> bytes:
         # avoiding blobfile for public files helps avoid auth issues, like MFA prompts.
         import requests
 
-        resp = requests.get(blobpath)
+        resp = (session or requests).get(blobpath)
         resp.raise_for_status()
         return resp.content
 
@@ -32,7 +36,11 @@ def check_hash(data: bytes, expected_hash: str) -> bool:
     return actual_hash == expected_hash
 
 
-def read_file_cached(blobpath: str, expected_hash: str | None = None) -> bytes:
+def read_file_cached(
+    blobpath: str,
+    expected_hash: str | None = None,
+    session: requests.Session | None = None,
+) -> bytes:
     user_specified_cache = True
     if "TIKTOKEN_CACHE_DIR" in os.environ:
         cache_dir = os.environ["TIKTOKEN_CACHE_DIR"]
@@ -46,7 +54,7 @@ def read_file_cached(blobpath: str, expected_hash: str | None = None) -> bytes:
 
     if cache_dir == "":
         # disable caching
-        return read_file(blobpath)
+        return read_file(blobpath, session=session)
 
     cache_key = hashlib.sha1(blobpath.encode()).hexdigest()
 
@@ -63,7 +71,7 @@ def read_file_cached(blobpath: str, expected_hash: str | None = None) -> bytes:
         except OSError:
             pass
 
-    contents = read_file(blobpath)
+    contents = read_file(blobpath, session=session)
     if expected_hash and not check_hash(contents, expected_hash):
         raise ValueError(
             f"Hash mismatch for data downloaded from {blobpath} (expected {expected_hash}). "
@@ -92,6 +100,7 @@ def data_gym_to_mergeable_bpe_ranks(
     vocab_bpe_hash: str | None = None,
     encoder_json_hash: str | None = None,
     clobber_one_byte_tokens: bool = False,
+    session: requests.Session | None = None,
 ) -> dict[bytes, int]:
     # NB: do not add caching to this function
     rank_to_intbyte = [b for b in range(2**8) if chr(b).isprintable() and chr(b) != " "]
@@ -106,7 +115,7 @@ def data_gym_to_mergeable_bpe_ranks(
     assert len(rank_to_intbyte) == 2**8
 
     # vocab_bpe contains the merges along with associated ranks
-    vocab_bpe_contents = read_file_cached(vocab_bpe_file, vocab_bpe_hash).decode()
+    vocab_bpe_contents = read_file_cached(vocab_bpe_file, vocab_bpe_hash, session=session).decode()
     bpe_merges = [tuple(merge_str.split()) for merge_str in vocab_bpe_contents.split("\n")[1:-1]]
 
     def decode_data_gym(value: str) -> bytes:
@@ -128,7 +137,7 @@ def data_gym_to_mergeable_bpe_ranks(
     # check that the encoder file matches the merges file
     # this sanity check is important since tiktoken assumes that ranks are ordered the same
     # as merge priority
-    encoder_json = json.loads(read_file_cached(encoder_json_file, encoder_json_hash))
+    encoder_json = json.loads(read_file_cached(encoder_json_file, encoder_json_hash, session=session))
     encoder_json_loaded = {decode_data_gym(k): v for k, v in encoder_json.items()}
     # drop these two special tokens if present, since they're not mergeable bpe tokens
     encoder_json_loaded.pop(b"<|endoftext|>", None)
@@ -156,9 +165,13 @@ def dump_tiktoken_bpe(bpe_ranks: dict[bytes, int], tiktoken_bpe_file: str) -> No
             f.write(base64.b64encode(token) + b" " + str(rank).encode() + b"\n")
 
 
-def load_tiktoken_bpe(tiktoken_bpe_file: str, expected_hash: str | None = None) -> dict[bytes, int]:
+def load_tiktoken_bpe(
+    tiktoken_bpe_file: str,
+    expected_hash: str | None = None,
+    session: requests.Session | None = None,
+) -> dict[bytes, int]:
     # NB: do not add caching to this function
-    contents = read_file_cached(tiktoken_bpe_file, expected_hash)
+    contents = read_file_cached(tiktoken_bpe_file, expected_hash, session=session)
     ret = {}
     for line in contents.splitlines():
         if not line:


### PR DESCRIPTION
Fix #259

## Summary

`tiktoken.load.read_file` (and the functions that call it) always used the module-level `requests.get`, so there was no way to route the download requests through a custom `requests.Session`. This adds an optional `session` parameter that flows through the whole loading chain, defaulting to `None` so existing behavior (`requests.get`) is unchanged when no session is provided.

## Changes

- `read_file(blobpath, session=None)`: uses `(session or requests).get(blobpath)` instead of always calling `requests.get`.
- `read_file_cached(blobpath, expected_hash=None, session=None)`: accepts and forwards `session` to `read_file`.
- `data_gym_to_mergeable_bpe_ranks(...)`: accepts `session` and forwards it to `read_file_cached`.
- `load_tiktoken_bpe(tiktoken_bpe_file, expected_hash=None, session=None)`: accepts `session` and forwards it to `read_file_cached`.
- Added `tests/test_load.py` with a fake `requests.Session` to verify `read_file` uses the provided session instead of the default `requests` module.

## Test plan

- [x] `pytest tests/test_load.py` — new test verifies a custom session is used for the HTTP GET instead of the module-level `requests.get`.
- [x] Existing behavior preserved: calling `read_file`/`read_file_cached`/`load_tiktoken_bpe`/`data_gym_to_mergeable_bpe_ranks` without a `session` still uses `requests.get` directly.
