### PR TITLE
fix: reject empty special token strings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -620,6 +620,10 @@ impl CoreBPE {
         special_tokens_encoder: HashMap<String, Rank>,
         pattern: &str,
     ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        if special_tokens_encoder.contains_key("") {
+            return Err("special token strings must not be empty".into());
+        }
+
         let regex = Regex::new(pattern)?;
 
         let special_regex = {
@@ -677,10 +681,9 @@ impl CoreBPE {
 
 #[cfg(test)]
 mod tests {
-    use fancy_regex::Regex;
     use rustc_hash::FxHashMap as HashMap;
 
-    use crate::{Rank, byte_pair_split};
+    use crate::{CoreBPE, Rank, byte_pair_split};
 
     fn setup_ranks() -> HashMap<Vec<u8>, Rank> {
         HashMap::from_iter([(b"ab".to_vec(), 0), (b"cd".to_vec(), 1)])
@@ -698,5 +701,20 @@ mod tests {
         let ranks = setup_ranks();
         let res = byte_pair_split(b"abab", &ranks);
         assert_eq!(res, vec![b"ab", b"ab"]);
+    }
+
+    #[test]
+    fn test_empty_special_token_is_rejected() {
+        let result = CoreBPE::new_internal(
+            HashMap::from_iter([(b"a".to_vec(), 0)]),
+            HashMap::from_iter([("".to_string(), 1)]),
+            ".",
+        );
+
+        let error = match result {
+            Ok(_) => panic!("empty special token should be rejected"),
+            Err(error) => error,
+        };
+        assert_eq!(error.to_string(), "special token strings must not be empty");
     }
 }

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -223,6 +223,16 @@ def test_special_token():
     assert fim in tokens
 
 
+def test_empty_special_token_is_rejected():
+    with pytest.raises(ValueError, match="special token strings must not be empty"):
+        tiktoken.Encoding(
+            name="empty_special",
+            pat_str=r"(?s).",
+            mergeable_ranks={bytes([i]): i for i in range(256)},
+            special_tokens={"": 256},
+        )
+
+
 @pytest.mark.parametrize("make_enc", ENCODING_FACTORIES)
 @hypothesis.given(text=st.text())
 @hypothesis.settings(deadline=None, max_examples=MAX_EXAMPLES)


### PR DESCRIPTION
## Summary

Reject empty special-token strings when constructing `CoreBPE`.

An empty special token produces a zero-width match. If that token is allowed
while encoding non-empty text, the match does not advance the encoding cursor,
so the operation does not complete. The configuration currently constructs
without an error.

## Changes

- Validate special-token strings in `CoreBPE::new_internal`.
- Return a clear `ValueError` through the existing Python constructor wrapper.
- Add a native Rust regression test.
- Add a Python API regression test.

## Validation

- `cargo test --lib` — 3 passed
- `pytest tests -q` — 34 passed
- `cargo fmt --check` — passed
- `git diff --check` — passed

## Disclosure

I used AI assistance during investigation and implementation. I reproduced the
behavior, reviewed the complete change, ran the validation above, and take
responsibility for the contribution.