### PR TITLE
fix(ci): replace invalid Actions pin with the commit SHA it resolves to

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: pypa/cibuildwheel@65b8265957fd86372d9689a0acdfd55813970d5d # v3.1.4
+      - uses: pypa/cibuildwheel@c923d83ad9c1bc00211c5041d0c3f73294ff88f6 # v3.1.4
         env:
           CIBW_BUILD: "cp${{ matrix.python-version}}-*"
           CIBW_ENABLE: cpython-freethreading
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@65b8265957fd86372d9689a0acdfd55813970d5d # v3.1.4
+        uses: pypa/cibuildwheel@c923d83ad9c1bc00211c5041d0c3f73294ff88f6 # v3.1.4
         env:
           CIBW_BUILD: "cp${{ matrix.python-version}}-*"
           CIBW_ARCHS: aarch64


### PR DESCRIPTION
## Problem

These workflow `uses:` pins are invalid as written. Each item below shows the current value, why it is wrong, and the correct ref that must be used instead.

### 1. `.github/workflows/build_wheels.yml`

**Current (invalid):**

```yaml
uses: pypa/cibuildwheel@65b8265957fd86372d9689a0acdfd55813970d5d # v3.1.4
```

**Why this is wrong:**

- `65b8265957fd86372d9689a0acdfd55813970d5d` is **not a commit SHA**. It is the Git object SHA of an **annotated tag** (`v3.1.4`).
- GitHub Actions does not accept annotated tag *object* SHAs in `uses:` pins (Commits API returns `No commit found for SHA`).
- The correct pin is the **commit SHA that tag `v3.1.4` points to**: `c923d83ad9c1bc00211c5041d0c3f73294ff88f6`.

**Correct pin:**

```yaml
uses: pypa/cibuildwheel@c923d83ad9c1bc00211c5041d0c3f73294ff88f6 # v3.1.4
```

## Test plan

- [ ] Each updated `uses:` ref resolves as a commit via the GitHub Commits API
- [ ] Relevant CI jobs on this branch look healthy
