### PR TITLE
Add DisallowedSpecialTokenError (ValueError subclass) for disallowed special tokens (#290)

### DIFF
--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -182,7 +182,7 @@ def test_special_token():
 
     text = "<|endoftext|> hello <|fim_prefix|>"
     assert eot not in enc.encode(text, disallowed_special=())
-    with pytest.raises(ValueError):
+    with pytest.raises(tiktoken.DisallowedSpecialTokenError):
         enc.encode(text)
     with pytest.raises(ValueError):
         enc.encode(text, disallowed_special="all")

--- a/tiktoken/__init__.py
+++ b/tiktoken/__init__.py
@@ -1,4 +1,5 @@
 # This is the public API of tiktoken
+from .core import DisallowedSpecialTokenError as DisallowedSpecialTokenError
 from .core import Encoding as Encoding
 from .model import encoding_for_model as encoding_for_model
 from .model import encoding_name_for_model as encoding_name_for_model

--- a/tiktoken/core.py
+++ b/tiktoken/core.py
@@ -13,6 +13,10 @@ if TYPE_CHECKING:
     import numpy.typing as npt
 
 
+class DisallowedSpecialTokenError(ValueError):
+    """Raised when text contains a special token that was not allowed."""
+
+
 class Encoding:
     def __init__(
         self,
@@ -439,7 +443,7 @@ def _special_token_regex(tokens: frozenset[str]) -> re.Pattern[str]:
 
 
 def raise_disallowed_special_token(token: str) -> NoReturn:
-    raise ValueError(
+    raise DisallowedSpecialTokenError(
         f"Encountered text corresponding to disallowed special token {token!r}.\n"
         "If you want this text to be encoded as a special token, "
         f"pass it to `allowed_special`, e.g. `allowed_special={{{token!r}, ...}}`.\n"


### PR DESCRIPTION
## Summary

This adds a dedicated `DisallowedSpecialTokenError` for the case where `encode()` encounters text corresponding to a special token that was not allowed.

The exception is exported from the top-level `tiktoken` package, so callers can handle this specific condition without matching the existing error message:

```python
try:
    encoding.encode(text)
except tiktoken.DisallowedSpecialTokenError:
    # Handle disallowed special-token input specifically.
    ...
```

## Why

Until now, this path raised a plain `ValueError`. That made it difficult for callers to distinguish a disallowed special token from other invalid input without relying on the exception message.

`DisallowedSpecialTokenError` subclasses `ValueError`, so existing code that catches `ValueError` continues to work unchanged. The message and detection behavior are also unchanged; only the concrete exception type is made more specific.

## Implementation

- Add `DisallowedSpecialTokenError(ValueError)` in `tiktoken.core`.
- Raise it from the existing centralized `raise_disallowed_special_token()` helper, covering all current encode paths.
- Re-export it from `tiktoken` as part of the public API.
- Extend the existing special-token test to assert the dedicated exception while retaining coverage that it is catchable as `ValueError`.

## Validation

- Focused special-token test: 1 passed.
- Full test suite with a deterministic Hypothesis seed: 33 passed.
- Verified the public exception MRO includes `ValueError`.

Closes #290