### PR TITLE
Add `get_token_length` methods to more cheaply calculate token lengths

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,10 @@ struct State {
     cur_rank: Rank,
 }
 
-fn _byte_pair_merge_large(ranks: &HashMap<Vec<u8>, Rank>, piece: &[u8]) -> Vec<Rank> {
+fn _byte_pair_merge_large_state(
+    ranks: &HashMap<Vec<u8>, Rank>,
+    piece: &[u8],
+) -> (Vec<State>, usize) {
     let mut state = Vec::with_capacity(piece.len());
     state.push(State {
         prev: usize::MAX,
@@ -94,6 +97,7 @@ fn _byte_pair_merge_large(ranks: &HashMap<Vec<u8>, Rank>, piece: &[u8]) -> Vec<R
         }
     };
 
+    let mut token_count = piece.len();
     while let Some(left) = heap.pop() {
         if left.rank == Rank::MAX {
             break;
@@ -109,6 +113,7 @@ fn _byte_pair_merge_large(ranks: &HashMap<Vec<u8>, Rank>, piece: &[u8]) -> Vec<R
         let right_next_end = state[right_start].next_end;
 
         // Merge left and right into a single token
+        token_count -= 1;
         state[left_start].cur_rank = state[left_start].next_rank;
         state[left_start].end = right_end;
         potential_merge(&mut state, &mut heap, left_start, right_next_end);
@@ -124,7 +129,12 @@ fn _byte_pair_merge_large(ranks: &HashMap<Vec<u8>, Rank>, piece: &[u8]) -> Vec<R
         state[right_start].next_rank = Rank::MAX;
     }
 
-    let mut result = Vec::new();
+    (state, token_count)
+}
+
+fn _byte_pair_merge_large(ranks: &HashMap<Vec<u8>, Rank>, piece: &[u8]) -> Vec<Rank> {
+    let (state, token_count) = _byte_pair_merge_large_state(ranks, piece);
+    let mut result = Vec::with_capacity(token_count);
     let mut i = 0;
     while i < state.len() {
         if state[i].cur_rank != Rank::MAX {
@@ -134,6 +144,7 @@ fn _byte_pair_merge_large(ranks: &HashMap<Vec<u8>, Rank>, piece: &[u8]) -> Vec<R
         }
         i = state[i].end;
     }
+    debug_assert_eq!(result.len(), token_count);
     result
 }
 
@@ -208,6 +219,18 @@ pub fn byte_pair_encode(piece: &[u8], ranks: &HashMap<Vec<u8>, Rank>) -> Vec<Ran
             .collect();
     }
     _byte_pair_merge_large(ranks, piece)
+}
+
+pub fn byte_pair_encode_count(piece: &[u8], ranks: &HashMap<Vec<u8>, Rank>) -> usize {
+    let piece_len = piece.len();
+
+    if piece_len == 1 {
+        return 1;
+    }
+    if piece_len < 100 {
+        return _byte_pair_merge(ranks, piece).len() - 1;
+    }
+    _byte_pair_merge_large_state(ranks, piece).1
 }
 
 pub fn byte_pair_split<'a>(piece: &'a [u8], ranks: &HashMap<Vec<u8>, Rank>) -> Vec<&'a [u8]> {
@@ -372,6 +395,19 @@ impl CoreBPE {
         ret
     }
 
+    pub fn get_token_length_ordinary(&self, text: &str) -> usize {
+        let regex = self._get_tl_regex();
+        let mut token_count = 0;
+        for mat in regex.find_iter(text) {
+            let piece = mat.unwrap().as_str().as_bytes();
+            token_count += match self.encoder.get(piece) {
+                Some(_) => 1,
+                None => byte_pair_encode_count(piece, &self.encoder),
+            };
+        }
+        token_count
+    }
+
     pub fn encode(
         &self,
         text: &str,
@@ -439,6 +475,62 @@ impl CoreBPE {
         // last_piece_token_len is how many tokens came from the last regex split. This is used
         // for determining unstable tokens, since you can't merge across (stable) regex splits
         Ok((ret, last_piece_token_len))
+    }
+
+    pub fn get_token_length(
+        &self,
+        text: &str,
+        allowed_special: &HashSet<&str>,
+    ) -> Result<usize, EncodeError> {
+        let special_regex = self._get_tl_special_regex();
+        let regex = self._get_tl_regex();
+        let mut token_count = 0;
+
+        let mut start = 0;
+        loop {
+            let mut next_special;
+            let mut start_find = start;
+            loop {
+                next_special = special_regex.find_from_pos(text, start_find).unwrap();
+                match next_special {
+                    Some(m) => {
+                        if allowed_special.contains(&text[m.start()..m.end()]) {
+                            break;
+                        }
+                        start_find = m.start() + 1;
+                    }
+                    None => break,
+                }
+            }
+            let end = next_special.map_or(text.len(), |m| m.start());
+
+            for mat_res in regex.find_iter(&text[start..end]) {
+                let mat = match mat_res {
+                    Ok(m) => m,
+                    Err(e) => {
+                        return Err(EncodeError {
+                            message: format!("Regex error while tokenizing: {e}"),
+                        });
+                    }
+                };
+
+                let piece = mat.as_str().as_bytes();
+                token_count += match self.encoder.get(piece) {
+                    Some(_) => 1,
+                    None => byte_pair_encode_count(piece, &self.encoder),
+                };
+            }
+
+            match next_special {
+                Some(m) => {
+                    token_count += 1;
+                    start = m.end();
+                }
+                None => break,
+            }
+        }
+
+        Ok(token_count)
     }
 
     fn _increase_last_piece_token_len(
@@ -677,10 +769,9 @@ impl CoreBPE {
 
 #[cfg(test)]
 mod tests {
-    use fancy_regex::Regex;
     use rustc_hash::FxHashMap as HashMap;
 
-    use crate::{Rank, byte_pair_split};
+    use crate::{Rank, byte_pair_encode, byte_pair_encode_count, byte_pair_split};
 
     fn setup_ranks() -> HashMap<Vec<u8>, Rank> {
         HashMap::from_iter([(b"ab".to_vec(), 0), (b"cd".to_vec(), 1)])
@@ -691,6 +782,7 @@ mod tests {
         let ranks = setup_ranks();
         let res = byte_pair_split(b"abcd", &ranks);
         assert_eq!(res, vec![b"ab", b"cd"]);
+        assert_eq!(byte_pair_encode_count(b"abcd", &ranks), res.len());
     }
 
     #[test]
@@ -698,5 +790,21 @@ mod tests {
         let ranks = setup_ranks();
         let res = byte_pair_split(b"abab", &ranks);
         assert_eq!(res, vec![b"ab", b"ab"]);
+        assert_eq!(byte_pair_encode_count(b"abab", &ranks), res.len());
+    }
+
+    #[test]
+    fn test_large_piece_token_count() {
+        let ranks = HashMap::from_iter([
+            (b"aa".to_vec(), 0),
+            (b"aaa".to_vec(), 1),
+            (b"a".to_vec(), 2),
+        ]);
+        let piece = b"a".repeat(101);
+
+        assert_eq!(
+            byte_pair_encode_count(&piece, &ranks),
+            byte_pair_encode(&piece, &ranks).len()
+        );
     }
 }

--- a/src/py.rs
+++ b/src/py.rs
@@ -31,6 +31,11 @@ impl CoreBPE {
         py.detach(|| self.encode_ordinary(text))
     }
 
+    #[pyo3(name = "get_token_length_ordinary")]
+    fn py_get_token_length_ordinary(&self, py: Python, text: &str) -> usize {
+        py.detach(|| self.get_token_length_ordinary(text))
+    }
+
     #[pyo3(name = "encode")]
     fn py_encode(
         &self,
@@ -45,6 +50,21 @@ impl CoreBPE {
                 Ok((tokens, _)) => Ok(tokens),
                 Err(e) => Err(PyErr::new::<exceptions::PyValueError, _>(e.message)),
             }
+        })
+    }
+
+    #[pyo3(name = "get_token_length")]
+    fn py_get_token_length(
+        &self,
+        py: Python,
+        text: &str,
+        allowed_special: HashSet<PyBackedStr>,
+    ) -> PyResult<usize> {
+        py.detach(|| {
+            let allowed_special: HashSet<&str> =
+                allowed_special.iter().map(|s| s.as_ref()).collect();
+            self.get_token_length(text, &allowed_special)
+                .map_err(|e| PyErr::new::<exceptions::PyValueError, _>(e.message))
         })
     }
 

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -53,8 +53,11 @@ def test_large_repeated():
     enc = tiktoken.get_encoding("o200k_base")
 
     # Large inputs should be handled without raising.
-    tokens = enc.encode("x" * 1_000_000)
+    text = "x" * 1_000_000
+    tokens = enc.encode(text)
     assert tokens
+    assert enc.get_token_length(text) == len(tokens)
+    assert enc.get_token_length_ordinary(text) == len(enc.encode_ordinary(text))
 
 
 def test_simple_regex():
@@ -105,9 +108,13 @@ def test_encode_surrogate_pairs():
     assert enc.encode("👍") == [9468, 239, 235]
     # surrogate pair gets converted to codepoint
     assert enc.encode("\ud83d\udc4d") == [9468, 239, 235]
+    assert enc.get_token_length("\ud83d\udc4d") == 3
+    assert enc.get_token_length_ordinary("\ud83d\udc4d") == 3
 
     # lone surrogate just gets replaced
     assert enc.encode("\ud83d") == enc.encode("�")
+    assert enc.get_token_length("\ud83d") == len(enc.encode("�"))
+    assert enc.get_token_length_ordinary("\ud83d") == len(enc.encode_ordinary("�"))
 
 
 @pytest.mark.parametrize("make_enc", ENCODING_FACTORIES)
@@ -153,6 +160,18 @@ def test_hyp_roundtrip(make_enc: Callable[[], tiktoken.Encoding], text):
     enc = make_enc()
 
     assert text == enc.decode(enc.encode(text))
+
+
+@pytest.mark.parametrize("make_enc", ENCODING_FACTORIES)
+@hypothesis.given(text=st.text())
+@hypothesis.settings(deadline=None, max_examples=MAX_EXAMPLES)
+def test_hyp_token_length(make_enc: Callable[[], tiktoken.Encoding], text: str):
+    enc = make_enc()
+
+    assert enc.get_token_length(text, disallowed_special=()) == len(
+        enc.encode(text, disallowed_special=())
+    )
+    assert enc.get_token_length_ordinary(text) == len(enc.encode_ordinary(text))
 
 
 @pytest.mark.parametrize("make_enc", ENCODING_FACTORIES)
@@ -221,6 +240,36 @@ def test_special_token():
     assert eot not in tokens
     assert fip not in tokens
     assert fim in tokens
+
+
+@pytest.mark.parametrize(
+    ("allowed_special", "disallowed_special"),
+    [
+        ("all", "all"),
+        (set(), ()),
+        ({"<|endoftext|>"}, ()),
+        ({"<|fim_prefix|>"}, ()),
+        ({"<|fim_middle|>"}, ()),
+    ],
+)
+def test_get_token_length_special(allowed_special, disallowed_special):
+    enc = tiktoken.get_encoding("cl100k_base")
+    text = "<|endoftext|> hello <|fim_prefix|> there <|fim_middle|>"
+
+    assert enc.get_token_length(
+        text,
+        allowed_special=allowed_special,
+        disallowed_special=disallowed_special,
+    ) == len(
+        enc.encode(
+            text,
+            allowed_special=allowed_special,
+            disallowed_special=disallowed_special,
+        )
+    )
+
+    with pytest.raises(ValueError):
+        enc.get_token_length(text)
 
 
 @pytest.mark.parametrize("make_enc", ENCODING_FACTORIES)

--- a/tiktoken/core.py
+++ b/tiktoken/core.py
@@ -79,6 +79,22 @@ class Encoding:
             text = text.encode("utf-16", "surrogatepass").decode("utf-16", "replace")
             return self._core_bpe.encode_ordinary(text)
 
+    def get_token_length_ordinary(self, text: str) -> int:
+        """Counts tokens in a string, ignoring special tokens.
+
+        This is equivalent to `len(encode_ordinary(text))`, without materialising the token list.
+
+        ```
+        >>> enc.get_token_length_ordinary("hello world")
+        2
+        ```
+        """
+        try:
+            return self._core_bpe.get_token_length_ordinary(text)
+        except UnicodeEncodeError:
+            text = text.encode("utf-16", "surrogatepass").decode("utf-16", "replace")
+            return self._core_bpe.get_token_length_ordinary(text)
+
     def encode(
         self,
         text: str,
@@ -134,6 +150,41 @@ class Encoding:
             # Also we use errors="replace" to handle weird things like lone surrogates.
             text = text.encode("utf-16", "surrogatepass").decode("utf-16", "replace")
             return self._core_bpe.encode(text, allowed_special)
+
+    def get_token_length(
+        self,
+        text: str,
+        *,
+        allowed_special: Literal["all"] | AbstractSet[str] = set(),  # noqa: B006
+        disallowed_special: Literal["all"] | Collection[str] = "all",
+    ) -> int:
+        """Counts tokens in a string.
+
+        This is equivalent to `len(encode(text, ...))`, without materialising the token list.
+        See `encode` for details on controlling special tokens.
+
+        ```
+        >>> enc.get_token_length("hello world")
+        2
+        >>> enc.get_token_length("<|endoftext|>", allowed_special="all")
+        1
+        ```
+        """
+        if allowed_special == "all":
+            allowed_special = self.special_tokens_set
+        if disallowed_special == "all":
+            disallowed_special = self.special_tokens_set - allowed_special
+        if disallowed_special:
+            if not isinstance(disallowed_special, frozenset):
+                disallowed_special = frozenset(disallowed_special)
+            if match := _special_token_regex(disallowed_special).search(text):
+                raise_disallowed_special_token(match.group())
+
+        try:
+            return self._core_bpe.get_token_length(text, allowed_special)
+        except UnicodeEncodeError:
+            text = text.encode("utf-16", "surrogatepass").decode("utf-16", "replace")
+            return self._core_bpe.get_token_length(text, allowed_special)
 
     def encode_to_numpy(
         self,


### PR DESCRIPTION
This PR adds Rust-backed `get_token_length` and `get_token_length_ordinary` Python methods that count tokens without materializing the encoded token list. They're written to match `encode` and `encode_ordinary`, confirmed by tests.

We have a Python service that creates the _payload_ for LLM requests, and needs to calculate the number of tokens to avoid creating too large payloads for a given LLM model.

We have used `len(enc.encode_ordinary(<message>))` for this, but we would very much like to reduce the footprint of the service on ours servers. With this change we move the counting to the Rust program, which is significantly more efficient.

For a single 100,000-token input, this reduced the returned result from 3.43 MiB to 28 bytes and used 4–6% less CPU. Includes Rust and Python correctness tests.

The code was written by 5.6 Sol on max effort.