### PR TITLE
Validate base64 tokens when loading BPE files

### DIFF
--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -1,0 +1,20 @@
+import base64
+
+import pytest
+
+from tiktoken.load import load_tiktoken_bpe
+
+
+def test_load_tiktoken_bpe_rejects_invalid_base64(tmp_path) -> None:
+    path = tmp_path / "invalid.tiktoken"
+    path.write_bytes(b"!!! 0\n")
+
+    with pytest.raises(ValueError, match=r"Error parsing line b'!!! 0'"):
+        load_tiktoken_bpe(str(path))
+
+
+def test_load_tiktoken_bpe_accepts_valid_base64(tmp_path) -> None:
+    path = tmp_path / "valid.tiktoken"
+    path.write_bytes(base64.b64encode(b"hello") + b" 42\n")
+
+    assert load_tiktoken_bpe(str(path)) == {b"hello": 42}

--- a/tiktoken/load.py
+++ b/tiktoken/load.py
@@ -165,7 +165,7 @@ def load_tiktoken_bpe(tiktoken_bpe_file: str, expected_hash: str | None = None) 
             continue
         try:
             token, rank = line.split()
-            ret[base64.b64decode(token)] = int(rank)
+            ret[base64.b64decode(token, validate=True)] = int(rank)
         except Exception as e:
             raise ValueError(f"Error parsing line {line!r} in {tiktoken_bpe_file}") from e
     return ret


### PR DESCRIPTION
## Summary

Reject malformed Base64 token fields when loading `.tiktoken` BPE files instead of silently discarding invalid characters.

Python's permissive `base64.b64decode` turns input such as `!!!` into `b""`, so a corrupted vocabulary line could create an empty-byte token and continue loading. Enabling the standard library's strict validation keeps the existing per-line error context while preventing silent vocabulary corruption.

## Testing

- `.venv/bin/python -m pytest tests/test_load.py -q` (2 passed)
- `.venv/bin/python -m pytest tests -q --deselect tests/test_encoding.py::test_simple --deselect tests/test_encoding.py::test_basic_encode` (31 passed, 4 deselected by existing test selection)
- `.venv/bin/python -m compileall -q tiktoken tests/test_load.py`
- `git diff --check`

The two deselected tests fetch tokenizer assets from `openaipublic.blob.core.windows.net`; they failed before assertions because the local proxy terminated TLS with `UNEXPECTED_EOF_WHILE_READING`. The new loader tests use local files and cover both valid and invalid Base64 deterministically.
